### PR TITLE
perf: dedup + batch authoritativeDefinitions resolution

### DIFF
--- a/src/embed.jsx
+++ b/src/embed.jsx
@@ -88,8 +88,10 @@ const DEFAULT_CONFIG = {
   saveLabel: 'Save',   // string - custom label for Save button in EMBEDDED mode
 	titlePrefix: null,
 
-  // Semantic ontology tree browser (the tree may also include business definitions)
-  semantics: null, // { baseUrl, pageParam, queryParam }
+  // Semantic ontology tree browser (the tree may also include business definitions).
+  // `batchResolveUrl` (optional): host endpoint that resolves many authoritativeDefinitions
+  // in one POST {refs:[{url}]} -> [{url, found, definition}]; enables batched link resolution.
+  semantics: null, // { baseUrl, pageParam, queryParam, definitionAcceptHeader, batchResolveUrl }
 
   managedTags: [], // [{tag: 'tag1', href: 'https://...'}, ...]
   allowUnmanagedTags: true,

--- a/src/hooks/useDefinition.js
+++ b/src/hooks/useDefinition.js
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useEditorStore } from '../store.js';
-import { fetchDefinition, fetchSemanticTree } from '../lib/definitionsApi.js';
-import { isExternalUrl } from "../lib/urlUtils.js";
+import { loadDefinition, fetchSemanticTree } from '../lib/definitionsApi.js';
+import { isExternalUrl, toAbsoluteUrl } from "../lib/urlUtils.js";
 
 /**
  * Hook for fetching definitions on-demand from the semantic ontology tree.
@@ -10,16 +10,27 @@ import { isExternalUrl } from "../lib/urlUtils.js";
 export function useDefinition() {
     const editorConfig = useEditorStore(state => state.editorConfig);
     const semantics = editorConfig?.semantics;
+    const csrf = editorConfig?.csrf;
+
+    // Config for the shared definition loader. When `batchResolveUrl` is set the
+    // loader coalesces all of a contract's authoritativeDefinitions into one POST;
+    // otherwise it dedups and falls back to per-URL fetches.
+    const loaderConfig = useMemo(() => ({
+        batchUrl: semantics?.batchResolveUrl ? toAbsoluteUrl(semantics.batchResolveUrl) : null,
+        acceptHeader: semantics?.definitionAcceptHeader,
+        csrf,
+    }), [semantics?.batchResolveUrl, semantics?.definitionAcceptHeader, csrf]);
 
     /**
-     * Fetch a single definition by URL
+     * Fetch a single definition by URL. Routes through the shared dedup+batch
+     * loader so identical URLs and same-tick requests collapse into one call.
      */
     const getDefinition = useCallback(async (definitionUrl) => {
         if (!definitionUrl || isExternalUrl(definitionUrl)) {
             return null;
         }
-        return await fetchDefinition(definitionUrl, semantics?.definitionAcceptHeader);
-    }, [semantics?.definitionAcceptHeader]);
+        return await loadDefinition(toAbsoluteUrl(definitionUrl), loaderConfig);
+    }, [loaderConfig]);
 
     /**
      * Fetch the semantic ontology tree

--- a/src/lib/definitionsApi.js
+++ b/src/lib/definitionsApi.js
@@ -35,6 +35,95 @@ export const fetchDefinition = async (url, definitionAcceptHeader = "application
 	}
 };
 
+// --- Shared definition resolution: dedup + microtask batching ----------------
+// On load, many components (diagram nodes, property rows, detail panels, preview)
+// each resolve the authoritativeDefinitions of every column. Resolving them one
+// URL at a time was a request-per-link N+1 that dominated editor load for
+// contracts with many semantic links. This shared loader collapses that:
+//   - identical URLs share a single cached promise (dedup across all callers), and
+//   - every URL requested within the same tick is coalesced into ONE batch POST
+//     to the host's resolve endpoint (when configured), else it falls back to the
+//     legacy per-URL GET so older hosts keep working.
+
+const definitionCache = new Map(); // absolute url -> Promise<Object|null>
+let pendingQueue = []; // [{ url, resolve, config }]
+let flushScheduled = false;
+
+/** Clears the per-session definition cache (e.g. for tests). */
+export const clearDefinitionCache = () => {
+	definitionCache.clear();
+};
+
+const flushDefinitionQueue = async () => {
+	flushScheduled = false;
+	const batch = pendingQueue;
+	pendingQueue = [];
+
+	// All callers in a tick share the same editor config, so the first is representative.
+	const config = batch[0]?.config || {};
+	const batchUrl = config.batchUrl || null;
+	const acceptHeader = config.acceptHeader || 'application/json';
+	const csrf = config.csrf || null;
+	const urls = [...new Set(batch.map((item) => item.url))];
+
+	const byUrl = new Map();
+	try {
+		if (!batchUrl) throw new Error('no batch resolve url configured');
+
+		const headers = { 'Content-Type': 'application/json', Accept: 'application/json' };
+		// Batch resolve is a POST, so include the CSRF header when the host provides one.
+		if (csrf?.headerName && csrf?.token) headers[csrf.headerName] = csrf.token;
+
+		const response = await fetch(batchUrl, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({ refs: urls.map((url) => ({ url })) }),
+		});
+		if (!response.ok) throw new Error(`Batch resolve failed: ${response.status} ${response.statusText}`);
+
+		const results = await response.json();
+		for (const item of results || []) {
+			if (item && item.found && item.definition) byUrl.set(item.url, item.definition);
+		}
+		// URLs the batch didn't return are definitive misses.
+		for (const url of urls) if (!byUrl.has(url)) byUrl.set(url, null);
+	} catch (error) {
+		// Fallback keeps the editor working against hosts without the batch endpoint
+		// (or on transient failure). Only warn when a batch was actually attempted.
+		if (batchUrl) console.warn('Falling back to per-URL definition fetch:', error?.message || error);
+		await Promise.all(
+			urls.map(async (url) => {
+				byUrl.set(url, await fetchDefinition(url, acceptHeader));
+			})
+		);
+	}
+
+	for (const { url, resolve } of batch) resolve(byUrl.get(url) ?? null);
+};
+
+/**
+ * Resolve a single definition URL through the shared dedup + batch loader.
+ * Identical URLs share one in-flight/cached promise; all URLs requested in the
+ * same tick are coalesced into a single batch request.
+ * @param {string} url - Absolute definition URL
+ * @param {Object} [config] - { batchUrl, acceptHeader, csrf } from the editor config
+ * @returns {Promise<Object|null>} The definition object or null if not found
+ */
+export const loadDefinition = (url, config = {}) => {
+	if (!url) return Promise.resolve(null);
+	if (definitionCache.has(url)) return definitionCache.get(url);
+
+	const promise = new Promise((resolve) => {
+		pendingQueue.push({ url, resolve, config });
+		if (!flushScheduled) {
+			flushScheduled = true;
+			queueMicrotask(flushDefinitionQueue);
+		}
+	});
+	definitionCache.set(url, promise);
+	return promise;
+};
+
 /**
  * Fetch the semantic ontology tree (concepts with their properties as children).
  * The tree may also include business definitions merged in by the backend.

--- a/src/store.js
+++ b/src/store.js
@@ -410,7 +410,7 @@ export function defaultStoreConfig(set, get) {
 			domains: null,
 			tests: DEFAULT_TESTS_CONFIG,
 			ai: DEFAULT_AI_CONFIG,
-			semantics: null, // { baseUrl, pageParam, queryParam } for the semantic ontology tree API
+			semantics: null, // { baseUrl, pageParam, queryParam, definitionAcceptHeader, batchResolveUrl } for the semantic ontology tree API
       managedTags: [], // [{tag: 'tag1', href: 'https://...'}, ...]
       allowUnmanagedTags: true,
 			customizations: null, // See CUSTOMIZATION.md for documentation


### PR DESCRIPTION
## Problem

On editor load, every diagram node, property row, detail panel and preview resolves the `authoritativeDefinitions` of each column by fetching each URL individually (`fetchDefinition` → `useDefinition.getDefinition`), with no caching or deduplication. For a contract with many semantically-linked columns this is a request-per-link N+1 that dominates load time — the browser serializes the fetches into waves (~6 connections/host). Contracts without semantic links stay fast.

Measured in an embedded host (network capture on load):

| Contract | resolve requests on load | resolve span |
|---|---|---|
| 50 columns, no links | 0 | — |
| 50 columns with links | 50 | ~1.6 s |
| 150 columns with links | 150 | ~2.3 s |

(The same URL referenced by multiple columns — and the multiple components that each resolve a property — were also fetched repeatedly, with no shared cache.)

## Change

A shared, module-level loader in `src/lib/definitionsApi.js` that:

- **dedups** identical URLs across all callers via a per-session cache (`Map<url, Promise>`), and
- **coalesces** every URL requested within the same tick into a single batch `POST` to an optional host endpoint, configured via `semantics.batchResolveUrl`:
  ```
  POST {batchResolveUrl}
  { "refs": [ { "url": "…" }, … ] }
  → [ { "url": "…", "found": true, "definition": { /* same shape as the per-URL endpoint */ } }, … ]
  ```
- **falls back** to the legacy per-URL `GET` when `batchResolveUrl` is not configured or a batch call fails — so behavior is unchanged for hosts that don't provide the endpoint.

All existing call sites benefit transparently through `useDefinition()`/`getDefinition`; no component changes. CSRF is included on the POST when the host provides `csrf` in the editor config. Config is carried per-call, so there's no init-order race.

New optional config field: `semantics.batchResolveUrl` (documented in `embed.jsx` / `store.js`).

## Behavior verified
- Same-tick distinct URLs → exactly one POST; duplicate URL deduped; CSRF header sent.
- Resolved value cached (no refetch on subsequent calls).
- Not-found URL → `null`.
- Fallback to per-URL `GET` both when no `batchResolveUrl` is set and when the batch request errors (e.g. 500).
- `npm run lint` clean, `npm run build` succeeds.

## Notes
The batch endpoint is host-side; a reference implementation exists in the datamesh-manager/entropy-data host. The editor degrades gracefully without it.