### PR TITLE
Support hiding the team tags field via customization

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -111,7 +111,7 @@ The `pattern` field accepts regular expressions for input validation. Be aware t
 - `server`, `type`, `environment`, `description`
 
 #### team
-- `name`, `description`
+- `name`, `description`, `tags`
 
 #### team.members
 - `username`, `name`, `role`, `description`, `dateIn`, `dateOut`

--- a/src/routes/Team.jsx
+++ b/src/routes/Team.jsx
@@ -27,6 +27,7 @@ const Team = () => {
   // Check hidden status for standard properties
   const isNameHidden = useIsPropertyHidden('team', 'name');
   const isDescriptionHidden = useIsPropertyHidden('team', 'description');
+  const isTagsHidden = useIsPropertyHidden('team', 'tags');
 
   // Get standard property overrides
   const nameOverride = useStandardPropertyOverride('team', 'name');
@@ -222,12 +223,14 @@ const Team = () => {
               )}
 
               {/* Team Tags */}
-              <TagsInput
-                label={t('team.tags.label')}
-                value={team?.tags}
-                onChange={(value) => updateTeamField('tags', value)}
-                placeholder={t('team.tags.placeholder')}
-              />
+              {!isTagsHidden && (
+                <TagsInput
+                  label={t('team.tags.label')}
+                  value={team?.tags}
+                  onChange={(value) => updateTeamField('tags', value)}
+                  placeholder={t('team.tags.placeholder')}
+                />
+              )}
 
               {/* Custom Sections from Customization */}
               <CustomSections


### PR DESCRIPTION
## What & why

Adds `hidden: true` support for the team **tags** standard property, so hosts can hide the Team → Tags field from the form-based editor via customization (`dataContract.team.standardProperties` with `property: tags`, `hidden: true`). Mirrors the existing `hidden` handling for team `name` and `description`.

## Screenshots

Team section — tags shown (default) vs. hidden via customization:

<img width="1280" height="720" alt="dc-team-tags-default" src="https://github.com/user-attachments/assets/e5ffd92d-9834-4f16-8e2a-17d13777ee9f" />
<img width="1280" height="720" alt="dc-team-tags-hidden" src="https://github.com/user-attachments/assets/e2eacdb4-7c87-4948-b068-7841cef398f2" />

## How it works

- `Team.jsx`: adds `useIsPropertyHidden('team', 'tags')` and gates the `<TagsInput>` on it, exactly like `name` / `description`.
- `CUSTOMIZATION.md`: lists `tags` under the `team` level's available properties.

Consistent with the standard-property `hidden` semantics: form-only. The preview and Monaco YAML view are unaffected, and the value round-trips untouched.
