### PR TITLE
Document previously-undocumented customization properties

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -93,13 +93,13 @@ The `pattern` field accepts regular expressions for input validation. Be aware t
 ### Available Properties by Level
 
 #### root
-- `name`, `version`, `status`, `domain`, `tenant`, `tags`
+- `id`, `name`, `version`, `status`, `domain`, `tenant`, `tags`
 
 #### description
-- `purpose`, `usage`, `limitations`
+- `purpose`, `usage`, `limitations`, `authoritativeDefinitions`
 
 #### schema
-- `name`, `physicalType`, `physicalName`, `description`, `businessName`, `dataGranularityDescription`
+- `name`, `logicalType`, `physicalType`, `physicalName`, `description`, `businessName`, `dataGranularityDescription`, `tags`
 
 #### schema.properties
 - `name`, `logicalType`, `physicalType`, `physicalName`, `description`, `businessName`
@@ -121,6 +121,8 @@ The `pattern` field accepts regular expressions for input validation. Be aware t
 
 #### support
 - `channel`, `url`, `description`, `tool`, `scope`, `invitationUrl`
+
+> **Note:** override support is wired per field. `hidden` works for every property listed above. The other keys (`title`, `description`, `placeholder`, `required`, `enum`, `pattern`, `minLength`, `maxLength`) are honored only where the field supports them — for example `enum` applies to `schema.properties.classification`, `servers.type`, `servers.environment`, and `support.tool`/`scope`, while free-text and boolean fields typically honor just `hidden` (and sometimes `title`).
 
 ---
 


### PR DESCRIPTION
## What

Fills gaps in the **Available Properties by Level** reference — these standard properties are customizable in code but were unlisted:

- `root.id`
- `schema.logicalType`, `schema.tags`
- `description.authoritativeDefinitions`

Also adds a note clarifying that `hidden` is supported for every listed property, while the other override keys (`enum`, `pattern`, `title`, `required`, …) are wired per field.

Pure documentation accuracy — no behavior change.
