### PR TITLE
Honor the enum override on the schema physicalType field

### DIFF
--- a/src/components/features/SchemaEditor.jsx
+++ b/src/components/features/SchemaEditor.jsx
@@ -19,7 +19,7 @@ import {SparkleButton} from '../../ai/index.js';
 import {Disclosure, DisclosureButton, DisclosurePanel} from '@headlessui/react';
 import PropertyRow from './schema/PropertyRow.jsx';
 import {useSchemaOperations} from './schema/useSchemaOperations.js';
-import {useCustomization, useIsPropertyHidden, useStandardPropertyOverride} from '../../hooks/useCustomization.js';
+import {useCustomization, useIsPropertyHidden, useStandardPropertyOverride, convertEnumToOptions} from '../../hooks/useCustomization.js';
 import {useInheritedDefinition} from '../../hooks/useInheritedDefinition.js';
 import {CustomSections, UngroupedCustomProperties} from '../ui/CustomSection.jsx';
 import {DefinitionSelectionModal} from '../ui/DefinitionSelectionModal.jsx';
@@ -348,7 +348,9 @@ const SchemaEditor = ({schemaIndex}) => {
 	}, [jsonSchema]);
 
 	// Schema type options for the combobox
-	const schemaTypeOptions = [
+	// Physical-type options: the `enum` customization override (if any) restricts the choices;
+	// otherwise the built-in ODCS defaults are offered.
+	const schemaTypeOptions = convertEnumToOptions(physicalTypeOverride?.enum) || [
 		{id: 'table', name: 'table'},
 		{id: 'view', name: 'view'},
 		{id: 'stream', name: 'stream'},


### PR DESCRIPTION
## What & why

The schema-level `physicalType` field ignored the `enum` customization override — it was bound to a fixed `table`/`view`/`stream`/`object` datalist and never read `useStandardPropertyOverride('schema', 'physicalType').enum`. The `enum` documented for this field (and used in CUSTOMIZATION.md's Complete Example) silently did nothing.

Now the field's suggestion list is derived from the `enum` override when present, falling back to the built-in ODCS defaults otherwise. Option `label`s are honored via the existing `convertEnumToOptions` helper (the same path already used by other enum-backed fields).

## Testing

- `npm run build` passes.
- Minimal, self-contained change: the fixed `schemaTypeOptions` array now defaults from `convertEnumToOptions(physicalTypeOverride?.enum)`, so the three existing call sites (value display, onChange mapping, datalist) pick up the override with no other change. Default behavior is unchanged when no `enum` is set.
