### PR TITLE
Hide custom sections when all their properties are hidden

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -245,6 +245,8 @@ dataContract:
 
 The `customProperties` list references custom property names defined under the same level. Names must match exactly — if a reference can't be resolved, the section is skipped and a warning is logged to the browser console (`[Customization] customSection "..." references unknown customProperties: ...`).
 
+A section is **automatically hidden when all of its custom properties are hidden** — that is, every referenced property has `hidden: true` or is currently filtered out by its `condition`. This avoids showing an empty section header. The section keeps rendering as long as at least one of its properties is visible (including a `required` one), so a mandatory field is never hidden by this behavior.
+
 `positionAfter` is currently supported in the property detail drawer (`schema.properties` level) and renders the section inline after the named anchor. Sections without `positionAfter` render below the standard sections in the order they're declared.
 
 

--- a/src/components/ui/CustomSection.jsx
+++ b/src/components/ui/CustomSection.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { Disclosure, DisclosureButton, DisclosurePanel } from '@headlessui/react';
 import ChevronRightIcon from './icons/ChevronRightIcon';
 import CustomPropertyField from './CustomPropertyField';
+import { evaluateCondition } from '../../lib/conditionEvaluator';
 
 /**
  * Renders a collapsible section containing custom properties
@@ -47,22 +48,35 @@ const CustomSection = ({
 		}
 	}, [propertyNames, customPropertyConfigs, sectionConfig.section]);
 
-	// Don't render if no properties in this section
-	if (sectionProperties.length === 0) {
-		return null;
-	}
-
-	// Auto-expand if any property in the section is required
-	const hasRequiredField = useMemo(() => {
-		return sectionProperties.some((p) => p.required);
-	}, [sectionProperties]);
-
-	// Build context including current custom property values
+	// Build context including current custom property values (also used for condition evaluation)
 	const extendedContext = useMemo(() => ({
 		...context,
 		...values,
 		customProperties: values,
 	}), [context, values]);
+
+	// Properties that will actually render: not hidden, and any display `condition` passes.
+	// Mirrors CustomPropertyField's `shouldShow`, so the section is dropped entirely when every
+	// child is hidden or filtered out — rather than showing an empty section header.
+	const visibleProperties = useMemo(() => {
+		return sectionProperties.filter((p) => {
+			if (p.hidden === true) return false;
+			if (!p.condition) return true;
+			return evaluateCondition(p.condition, yamlParts, extendedContext);
+		});
+	}, [sectionProperties, yamlParts, extendedContext]);
+
+	// Auto-expand if any visible property in the section is required
+	const hasRequiredField = useMemo(() => {
+		return visibleProperties.some((p) => p.required);
+	}, [visibleProperties]);
+
+	// Don't render the section when nothing is visible (no resolvable properties, or every child
+	// is hidden / filtered by its condition). All hooks above run unconditionally so hook order
+	// stays stable across renders.
+	if (visibleProperties.length === 0) {
+		return null;
+	}
 
 	return (
 		<Disclosure defaultOpen={expanded || hasRequiredField}>


### PR DESCRIPTION
## What & why

A custom section rendered a header + empty panel when all of its custom properties were hidden (each `CustomPropertyField` self-gates on `hidden`/`condition` and returns null, but `CustomSection` only bailed when there were *zero resolvable* properties). Now a section is dropped entirely once none of its children are visible.

## How it works

- `CustomSection` computes `visibleProperties` = children that are `!hidden` **and** whose `condition` (if any) passes — mirroring `CustomPropertyField.shouldShow` — and returns `null` when that list is empty.
- All hooks were hoisted above the early return so hook order stays stable now that visibility can depend on values (`condition`).

## Safety / scope

- **No mandatory field is hidden.** A section keeps rendering as long as ≥1 child is visible, including a `required` one — verified: a section with a required child (even alongside a hidden sibling) still shows and auto-expands.
- **ODCS-safe.** Custom sections group only custom properties (ODCS's optional `customProperties`), never standard fields — so this can't drop an ODCS-required field. The underlying YAML is untouched (hidden values still round-trip).

## Testing

- `npm run build` passes.
- Verified in the running editor: an all-hidden section shows no header; a section with a visible child (or a required child) still renders.
