### PR TITLE
Support title/description/required overrides on schema property description and examples

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -122,7 +122,7 @@ The `pattern` field accepts regular expressions for input validation. Be aware t
 #### support
 - `channel`, `url`, `description`, `tool`, `scope`, `invitationUrl`
 
-> **Note:** override support is wired per field. `hidden` works for every property listed above. The other keys (`title`, `description`, `placeholder`, `required`, `enum`, `pattern`, `minLength`, `maxLength`) are honored only where the field supports them — for example `enum` applies to `schema.properties.classification`, `servers.type`, `servers.environment`, and `support.tool`/`scope`, while free-text and boolean fields typically honor just `hidden` (and sometimes `title`).
+> **Note:** override support is wired per field. `hidden` works for every property listed above. The other keys (`title`, `description`, `placeholder`, `required`, `enum`, `pattern`, `minLength`, `maxLength`) are honored only where the field supports them — for example `enum` applies to `schema.properties.classification`, `servers.type`, `servers.environment`, and `support.tool`/`scope`. Text fields such as `schema.properties.description` and `schema.properties.examples` honor `title`, `description`, `required`, `placeholder`, `minLength` and `maxLength` (for these two, `description` renders as help text **below** the field); boolean fields typically honor just `hidden` (and sometimes `title`). Where an override is not set, the built-in i18n label/help for the requested language is used.
 
 ---
 

--- a/src/components/diagram/PropertyDetailsPanel.jsx
+++ b/src/components/diagram/PropertyDetailsPanel.jsx
@@ -12,6 +12,7 @@ import AuthoritativeDefinitionsEditor from '../ui/AuthoritativeDefinitionsEditor
 import CustomPropertiesEditor from '../ui/CustomPropertiesEditor.jsx';
 import EnumField from '../ui/EnumField.jsx';
 import ValidatedInput from '../ui/ValidatedInput.jsx';
+import ValidatedTextarea from '../ui/ValidatedTextarea.jsx';
 import TagsInput from '../ui/TagsInput.jsx';
 import QualityEditor from '../ui/QualityEditor.jsx';
 import Tooltip from '../ui/Tooltip.jsx';
@@ -95,6 +96,8 @@ const PropertyDetailsPanel = ({ property, onUpdate, onDelete, focusSection, focu
   const partitionedOverride = useStandardPropertyOverride('schema.properties', 'partitioned');
   const criticalDataElementOverride = useStandardPropertyOverride('schema.properties', 'criticalDataElement');
   const transformSourceObjectsOverride = useStandardPropertyOverride('schema.properties', 'transformSourceObjects');
+  const descriptionOverride = useStandardPropertyOverride('schema.properties', 'description');
+  const examplesOverride = useStandardPropertyOverride('schema.properties', 'examples');
 
   // Convert array format to object lookup for UI components
   const customPropertiesLookup = useMemo(() => {
@@ -392,23 +395,30 @@ const PropertyDetailsPanel = ({ property, onUpdate, onDelete, focusSection, focu
               {/* Description */}
               {!isDescriptionHidden && (
                 <div>
-                  <div className="flex items-center justify-between mb-1">
-                    <label className="block text-xs font-medium text-gray-700">{t('diagram.field.description.label')}</label>
-                    <SparkleButton
-                      fieldName={`Description for "${property.name || 'property'}"`}
-                      fieldPath="property.description"
-                      currentValue={property.description}
-                      onSuggestion={(value) => updateField('description', value)}
-                      placeholder={`Description of the ${property.name || 'data'} field`}
-                    />
-                  </div>
-                  <textarea
+                  <ValidatedTextarea
+                    name="property-description"
+                    label={descriptionOverride?.title || t('diagram.field.description.label')}
                     value={property.description || ''}
                     onChange={(e) => updateField('description', e.target.value)}
-                    rows={3}
-                    className={`w-full rounded border border-gray-300 bg-white px-2 py-1 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs ${definitionData?.description && !property.description ? 'placeholder:text-blue-400' : ''}`}
-                    placeholder={definitionData?.description || t('diagram.field.description.placeholder')}
+                    required={descriptionOverride?.required}
+                    placeholder={definitionData?.description || descriptionOverride?.placeholder || t('diagram.field.description.placeholder')}
+                    placeholderClassName={definitionData?.description && !property.description ? 'placeholder:text-blue-400' : 'placeholder:text-gray-400'}
+                    minLength={descriptionOverride?.minLength}
+                    maxLength={descriptionOverride?.maxLength}
+                    actions={
+                      <SparkleButton
+                        fieldName={`Description for "${property.name || 'property'}"`}
+                        fieldPath="property.description"
+                        currentValue={property.description}
+                        onSuggestion={(value) => updateField('description', value)}
+                        placeholder={`Description of the ${property.name || 'data'} field`}
+                      />
+                    }
                   />
+                  {/* Customization `description` renders as help text below the field; no i18n fallback (no help key). */}
+                  {descriptionOverride?.description && (
+                    <p className="mt-1 text-xs text-gray-500">{descriptionOverride.description}</p>
+                  )}
                 </div>
               )}
               {renderCustomAfter('description')}
@@ -416,23 +426,26 @@ const PropertyDetailsPanel = ({ property, onUpdate, onDelete, focusSection, focu
               {/* Examples */}
               {!isExamplesHidden && (
                 <div>
-                  <label className="block text-xs font-medium text-gray-700 mb-1">{t('diagram.field.examples.label')}</label>
-                  <textarea
+                  <ValidatedTextarea
+                    name="property-examples"
+                    label={examplesOverride?.title || t('diagram.field.examples.label')}
                     value={property.examples?.join('\n') || ''}
                     onChange={(e) => {
                       const value = e.target.value;
                       if (value === '') {
                         updateField('examples', undefined);
                       } else {
-                        const examples = value.split('\n');
-                        updateField('examples', examples);
+                        updateField('examples', value.split('\n'));
                       }
                     }}
-                    rows={3}
-                    className={`w-full rounded border border-gray-300 bg-white px-2 py-1 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs ${definitionData?.examples && !property.examples ? 'placeholder:text-blue-400' : ''}`}
+                    required={examplesOverride?.required}
                     placeholder={definitionData?.examples ? definitionData.examples.join('\n') : "example1\nexample2\nexample3"}
+                    placeholderClassName={definitionData?.examples && !property.examples ? 'placeholder:text-blue-400' : 'placeholder:text-gray-400'}
+                    minLength={examplesOverride?.minLength}
+                    maxLength={examplesOverride?.maxLength}
                   />
-                  <p className="mt-1 text-xs text-gray-500">{t('diagram.field.examples.help')}</p>
+                  {/* Customization `description` overrides the help text below the field; falls back to i18n. */}
+                  <p className="mt-1 text-xs text-gray-500">{examplesOverride?.description || t('diagram.field.examples.help')}</p>
                 </div>
               )}
               {renderCustomAfter('examples')}


### PR DESCRIPTION
## What & why

At the `schema.properties` level, the **description** and **examples** fields only honored `hidden` — `required`, a `title` override, and a `description` (help text) override were all ignored (no `useStandardPropertyOverride` was wired for them; the label/help came from i18n only). This makes those two overridable, matching the pattern already used by `name`/`businessName`.

## How it works

- Each field now reads `useStandardPropertyOverride('schema.properties', 'description'|'examples')` and renders via `ValidatedTextarea` (the existing validated component), wiring `title`, `required`, `placeholder`, `minLength`, `maxLength`.
- The override `description` renders as **help text below** the field (as requested). For `examples` it overrides the existing i18n help; for `description` it adds one (no i18n help key exists).
- **Precedence:** the customization value wins when set; otherwise the built-in i18n label/help for the requested language is used (`override?.title || t(...)`).

## Testing

- `npm run build` passes.
- Verified end-to-end in the running editor: with overrides set, the property drawer shows the custom titles ("Field Description (custom)", "Sample Values (custom)"), the custom help text below each field, and a Required indicator + validation. Without overrides, the default i18n labels/help are used.

## Notes

- ODCS-safe: `description`/`examples` are optional ODCS fields; `required` here is a form-validation intent (the value still lands in the optional field), the YAML round-trips unchanged.
- `CUSTOMIZATION.md` updated to note these two fields' override support and the below-field help behavior.
