### PR TITLE
Resolve external authoritativeDefinition references via the backend resolver

### DIFF
--- a/src/components/diagram/PropertyDetailsPanel.jsx
+++ b/src/components/diagram/PropertyDetailsPanel.jsx
@@ -167,60 +167,49 @@ const PropertyDetailsPanel = ({ property, onUpdate, onDelete, focusSection, focu
 
   // Get semantic definition from authoritative definitions (type === 'semantics' / 'semantic', with fallback to 'definition')
   const semanticDefinition = useMemo(() => {
-    const def = property.authoritativeDefinitions?.find(d => isSemanticAuthDef(d))
+    return property.authoritativeDefinitions?.find(d => isSemanticAuthDef(d))
       || property.authoritativeDefinitions?.find(d => d.type === 'definition');
-    console.log('Semantic definition found:', def);
-    return def;
   }, [property.authoritativeDefinitions]);
 
-  // Get absolute URL and check if external
-  const semanticDefinitionAbsoluteUrl = useMemo(() => {
-    const url = semanticDefinition?.url ? toAbsoluteUrl(semanticDefinition.url) : null;
-    console.log('Absolute URL:', url, 'Original URL:', semanticDefinition?.url);
-    return url;
-  }, [semanticDefinition?.url]);
+  const semanticDefinitionAbsoluteUrl = useMemo(
+    () => (semanticDefinition?.url ? toAbsoluteUrl(semanticDefinition.url) : null),
+    [semanticDefinition?.url]
+  );
 
+  // Whether the reference points at a different host — drives the external-link
+  // affordance only. Resolution no longer depends on it: getDefinition resolves
+  // external/IRI references via the backend when configured.
   const isSemanticDefinitionExternal = useMemo(() => {
     if (!semanticDefinition?.url) return false;
-		return isExternalUrl(semanticDefinition.url);
+    return isExternalUrl(semanticDefinition.url);
   }, [semanticDefinition?.url]);
 
-  // Fetch definition data when semantic definition URL is available
+  // Fetch definition data when a semantic definition URL is available. getDefinition
+  // handles host-agnostic IRIs / external references through the backend resolver and
+  // returns null for anything it can't resolve, so there's no host gate here.
   useEffect(() => {
     if (!semanticDefinitionAbsoluteUrl) {
       setDefinitionData(null);
       return;
     }
 
-    // Only fetch for internal URLs to avoid CORS issues
-    if (isSemanticDefinitionExternal) {
-      console.log('Skipping fetch - external URL');
-      setDefinitionData(null);
-      return;
-    }
-
+    let cancelled = false;
     const fetchDefinitionData = async () => {
       setIsFetchingDefinition(true);
       try {
-        console.log('Fetching definition:', semanticDefinitionAbsoluteUrl);
         const data = await getDefinition(semanticDefinitionAbsoluteUrl);
-        if (data) {
-          console.log('Fetched definition data:', data);
-          setDefinitionData(data);
-        } else {
-          console.warn('No definition data returned for:', semanticDefinitionAbsoluteUrl);
-          setDefinitionData(null);
-        }
+        if (!cancelled) setDefinitionData(data || null);
       } catch (error) {
         console.error('Failed to fetch definition:', error);
-        setDefinitionData(null);
+        if (!cancelled) setDefinitionData(null);
       } finally {
-        setIsFetchingDefinition(false);
+        if (!cancelled) setIsFetchingDefinition(false);
       }
     };
 
     fetchDefinitionData();
-  }, [semanticDefinitionAbsoluteUrl, isSemanticDefinitionExternal, getDefinition]);
+    return () => { cancelled = true; };
+  }, [semanticDefinitionAbsoluteUrl, getDefinition]);
 
   // Remove semantic definition
   const removeSemanticDefinition = useCallback(() => {
@@ -488,9 +477,9 @@ const PropertyDetailsPanel = ({ property, onUpdate, onDelete, focusSection, focu
 
                       {/* Buttons - Right aligned */}
                       <div className="flex justify-end gap-2">
-                        {!isSemanticDefinitionExternal && (
+                        {(definitionData || isFetchingDefinition) && (
                           <Popover className="relative">
-                            {({ open }) => (
+                            {() => (
                               <>
                                 <PopoverButton className="rounded bg-white px-2 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:outline-none">
                                   {t('diagram.semantics.showDetails')}

--- a/src/hooks/useDefinition.js
+++ b/src/hooks/useDefinition.js
@@ -22,11 +22,16 @@ export function useDefinition() {
      * Fetch a single definition by URL
      */
     const getDefinition = useCallback(async (definitionUrl) => {
-        if (!definitionUrl || isExternalUrl(definitionUrl)) {
+        if (!definitionUrl) {
             return null;
         }
+        // A configured backend resolver handles external/IRI references too (server-side, no CORS).
         if (batchResolveUrl && resolveAuthoritativeDefinition) {
             return await resolveAuthoritativeDefinition(definitionUrl);
+        }
+        // Direct per-URL fetch works same-host only (CORS); skip external references.
+        if (isExternalUrl(definitionUrl)) {
+            return null;
         }
         return await fetchDefinition(definitionUrl, semantics?.definitionAcceptHeader);
     }, [batchResolveUrl, resolveAuthoritativeDefinition, semantics?.definitionAcceptHeader]);

--- a/src/hooks/useInheritedDefinition.js
+++ b/src/hooks/useInheritedDefinition.js
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useDefinition } from './useDefinition.js';
 import { isSemanticAuthDef } from '../utils/authDefTypes.js';
-import { toAbsoluteUrl, isExternalUrl } from '../lib/urlUtils.js';
+import { toAbsoluteUrl } from '../lib/urlUtils.js';
 
 /**
  * Resolve the semantic (or fallback `definition`) entry from an
@@ -37,16 +37,13 @@ export function useInheritedDefinition(authoritativeDefinitions) {
     [semanticDefinition?.url]
   );
 
-  const external = useMemo(
-    () => (semanticDefinition?.url ? isExternalUrl(semanticDefinition.url) : false),
-    [semanticDefinition?.url]
-  );
-
   useEffect(() => {
-    if (!absoluteUrl || external) {
+    if (!absoluteUrl) {
       setDefinitionData(null);
       return;
     }
+    // getDefinition resolves external/IRI references via the backend when configured,
+    // and returns null for references it cannot resolve — no need to gate on host here.
     let cancelled = false;
     setIsFetching(true);
     getDefinition(absoluteUrl)
@@ -62,7 +59,7 @@ export function useInheritedDefinition(authoritativeDefinitions) {
     return () => {
       cancelled = true;
     };
-  }, [absoluteUrl, external, getDefinition]);
+  }, [absoluteUrl, getDefinition]);
 
   // A field is "inherited" when the definition has it but the entity doesn't.
   const isInherited = (entity, field) =>

--- a/src/lib/authoritativeDefinitions.js
+++ b/src/lib/authoritativeDefinitions.js
@@ -1,5 +1,5 @@
 import { isSemanticAuthDef } from '../utils/authDefTypes.js';
-import { isInternalUrl, toAbsoluteUrl } from './urlUtils.js';
+import { toAbsoluteUrl } from './urlUtils.js';
 
 /**
  * Collect absolute URLs of authoritativeDefinitions entries that are resolvable
@@ -18,8 +18,11 @@ import { isInternalUrl, toAbsoluteUrl } from './urlUtils.js';
  *     or the deprecated `team[]` array; both members are TeamMember-shaped
  *
  * An entry qualifies when it is a semantic/business definition
- * (type 'semantics' | 'semantic' | 'definition'), has a url, and the url is
- * internal (same host). Collected urls are normalized to absolute and de-duped.
+ * (type 'semantics' | 'semantic' | 'definition') and has a url. External
+ * (different-host) urls are included too: this collection feeds the backend
+ * batch resolver, which resolves references server-side (including host-agnostic
+ * concept IRIs) with no CORS constraint. Collected urls are normalized to
+ * absolute and de-duped.
  *
  * @param {*} yamlParts - parsed contract (null-safe)
  * @returns {string[]} de-duplicated absolute urls (stable order)
@@ -32,7 +35,7 @@ export function collectAuthoritativeDefinitionUrls(yamlParts) {
     for (const entry of entries) {
       if (!entry || typeof entry !== 'object') continue;
       const qualifies = isSemanticAuthDef(entry) || entry.type === 'definition';
-      if (!qualifies || !entry.url || !isInternalUrl(entry.url)) continue;
+      if (!qualifies || !entry.url) continue;
       const abs = toAbsoluteUrl(entry.url);
       if (abs) urls.push(abs);
     }

--- a/src/lib/authoritativeDefinitions.test.js
+++ b/src/lib/authoritativeDefinitions.test.js
@@ -94,7 +94,7 @@ describe('collectAuthoritativeDefinitionUrls', () => {
     expect(collectAuthoritativeDefinitionUrls(contract)).toEqual([]);
   });
 
-  it('skips non-definition types, external URLs, and entries without a URL', () => {
+  it('skips non-definition types and entries without a URL, but keeps external URLs', () => {
     const contract = {
       authoritativeDefinitions: [
         { type: 'videoTutorial', url: '/org/definitions/video' },
@@ -102,7 +102,23 @@ describe('collectAuthoritativeDefinitionUrls', () => {
         { type: 'semantics' },
       ],
     };
-    expect(collectAuthoritativeDefinitionUrls(contract)).toEqual([]);
+    // The external URL is kept: the backend batch resolver handles it server-side
+    // (no CORS), so only the non-qualifying type and the url-less entry drop.
+    expect(collectAuthoritativeDefinitionUrls(contract)).toEqual([
+      'https://other-host.com/org/definitions/ext',
+    ]);
+  });
+
+  it('collects host-agnostic concept IRIs for backend resolution', () => {
+    const contract = {
+      schema: [
+        { properties: [{ authoritativeDefinitions: [sem('http://www.example-ns.com/ns/main/orderId')] }] },
+      ],
+    };
+    // An IRI is an identity string on any host; the backend resolves it by exact match.
+    expect(collectAuthoritativeDefinitionUrls(contract)).toEqual([
+      'http://www.example-ns.com/ns/main/orderId',
+    ]);
   });
 
   it('de-duplicates repeated URLs', () => {

--- a/src/lib/authoritativeDefinitionsSlice.js
+++ b/src/lib/authoritativeDefinitionsSlice.js
@@ -66,15 +66,20 @@ export function createAuthoritativeDefinitionsSlice(set, get) {
     },
 
     resolveAuthoritativeDefinition: async (url) => {
-      if (!url || isExternalUrl(url)) return null;
+      if (!url) return null;
       const abs = toAbsoluteUrl(url);
       if (!abs) return null;
 
       const batchResolveUrl = get().editorConfig?.semantics?.batchResolveUrl;
       if (!batchResolveUrl) {
+        // No backend resolver: fall back to a direct per-URL GET, which only works
+        // same-host (CORS). External references stay unresolved.
+        if (isExternalUrl(url)) return null;
         return fetchDefinition(abs, getAcceptHeader());
       }
 
+      // Backend-mediated resolution works for internal urls and host-agnostic IRIs
+      // alike (server-side lookup, no CORS), so external references resolve here too.
       if (has(get().authoritativeDefinitions.byUrl, abs)) {
         return get().authoritativeDefinitions.byUrl[abs];
       }
@@ -89,7 +94,11 @@ export function createAuthoritativeDefinitionsSlice(set, get) {
       if (inflight.has(abs)) return inflight.get(abs);
       const gen = generation;
       const p = (async () => {
-        const data = await fetchDefinition(abs, getAcceptHeader());
+        // Resolve the cache miss through the batch endpoint rather than a direct GET,
+        // so external/IRI references resolve too. The endpoint echoes the request url
+        // as the map key; a missing/null entry means "no match".
+        const map = await fetchAuthoritativeDefinitionsBatch(batchResolveUrl, [abs], 'application/json');
+        const data = map && has(map, abs) ? map[abs] : null;
         if (gen === generation) {
           set((state) => ({
             authoritativeDefinitions: {

--- a/src/lib/authoritativeDefinitionsSlice.test.js
+++ b/src/lib/authoritativeDefinitionsSlice.test.js
@@ -53,8 +53,11 @@ describe('createAuthoritativeDefinitionsSlice', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1); // batch only; cache hit, no extra call
   });
 
-  it('lazy-fetches and merges a URL missing from the batch', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ name: 'Lazy' }) });
+  it('lazy-resolves a URL missing from the batch via the batch endpoint', async () => {
+    const lateUrl = 'https://app.example.com/org/definitions/late';
+    // The lazy fallback re-uses the batch endpoint (server-side lookup), so the
+    // response is a url-keyed map, not a bare definition.
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ [lateUrl]: { name: 'Lazy' } }) });
     const { get } = makeStore(
       { semantics: { batchResolveUrl: 'https://api/batch' } },
       { authoritativeDefinitions: [] },
@@ -63,7 +66,7 @@ describe('createAuthoritativeDefinitionsSlice', () => {
 
     const data = await get().resolveAuthoritativeDefinition('/org/definitions/late');
     expect(data).toEqual({ name: 'Lazy' });
-    expect(get().authoritativeDefinitions.byUrl['https://app.example.com/org/definitions/late']).toEqual({ name: 'Lazy' });
+    expect(get().authoritativeDefinitions.byUrl[lateUrl]).toEqual({ name: 'Lazy' });
   });
 
   it('skips the batch request when no internal definition URLs are present', async () => {
@@ -77,11 +80,12 @@ describe('createAuthoritativeDefinitionsSlice', () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('batch error sets status error and resolveAuthoritativeDefinition falls back to single fetch', async () => {
+  it('batch error sets status error; resolveAuthoritativeDefinition retries via a single-URL batch', async () => {
+    const xUrl = 'https://app.example.com/org/definitions/x';
     global.fetch = vi
       .fn()
-      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'err' }) // batch fails
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ name: 'Fallback' }) }); // single
+      .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'err' }) // load batch fails
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ [xUrl]: { name: 'Fallback' } }) }); // lazy retry
     const { get } = makeStore(
       { semantics: { batchResolveUrl: 'https://api/batch' } },
       { authoritativeDefinitions: [ad('/org/definitions/x')] },
@@ -93,11 +97,12 @@ describe('createAuthoritativeDefinitionsSlice', () => {
     expect(data).toEqual({ name: 'Fallback' });
   });
 
-  it('lazy-fetches a URL the batch response omitted', async () => {
+  it('lazy-resolves a URL the batch response omitted', async () => {
+    const lateUrl = 'https://app.example.com/org/definitions/late';
     global.fetch = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ 'https://app.example.com/org/definitions/x': { name: 'X' } }) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ name: 'Lazy' }) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ [lateUrl]: { name: 'Lazy' } }) });
     const { get } = makeStore(
       { semantics: { batchResolveUrl: 'https://api/batch' } },
       { authoritativeDefinitions: [ad('/org/definitions/x')] },
@@ -107,14 +112,33 @@ describe('createAuthoritativeDefinitionsSlice', () => {
 
     const data = await get().resolveAuthoritativeDefinition('/org/definitions/late');
     expect(data).toEqual({ name: 'Lazy' });
-    expect(get().authoritativeDefinitions.byUrl['https://app.example.com/org/definitions/late']).toEqual({ name: 'Lazy' });
+    expect(get().authoritativeDefinitions.byUrl[lateUrl]).toEqual({ name: 'Lazy' });
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
-  it('returns null for external URLs in batch mode', async () => {
+  it('resolves an external URL / IRI via the batch endpoint in batch mode', async () => {
+    const iri = 'http://www.example-ns.com/ns/main/orderId';
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ [iri]: { name: 'Order ID' } }) });
+    const { get } = makeStore({ semantics: { batchResolveUrl: 'https://api/batch' } }, { authoritativeDefinitions: [] });
+    await get().collectAndFetchAuthoritativeDefinitions();
+
+    const data = await get().resolveAuthoritativeDefinition(iri);
+    expect(data).toEqual({ name: 'Order ID' });
+    expect(global.fetch).toHaveBeenCalledTimes(1); // routed to the backend, not skipped
+  });
+
+  it('returns null for an external URL the backend does not match', async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
     const { get } = makeStore({ semantics: { batchResolveUrl: 'https://api/batch' } }, { authoritativeDefinitions: [] });
     await get().collectAndFetchAuthoritativeDefinitions();
     expect(await get().resolveAuthoritativeDefinition('https://other-host.com/x')).toBeNull();
+  });
+
+  it('returns null for external URLs without a backend resolver, without fetching', async () => {
+    // No batchResolveUrl: only a same-host direct GET is possible, so external stays unresolved.
+    global.fetch = vi.fn();
+    const { get } = makeStore({ semantics: {} }, { authoritativeDefinitions: [] });
+    expect(await get().resolveAuthoritativeDefinition('https://other-host.com/x')).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What & why

Inherited definition values (Business Name, Logical Type, Examples, description, tags shown as blue placeholders on a linked property) were only fetched when the `authoritativeDefinitions` URL was **same-host**. External references were skipped to avoid CORS — but a concept reference can legitimately be a host-agnostic **IRI** (an identity string that may live on any host, and need not be directly dereferenceable), so those linked properties showed no inherited values and hid their "Show details" affordance.

When a backend resolver (`semantics.batchResolveUrl`) is configured, resolution already happens server-side with no CORS constraint. So there's no reason to skip external references — they just need to go through that resolver instead of a direct browser fetch.

## How it works

Host-gating is now applied **only** to the direct-fetch fallback (used when no `batchResolveUrl` is configured, where a cross-origin GET genuinely can't work). When a resolver is configured, all references — internal URLs and external/IRI alike — resolve through it:

- `collectAuthoritativeDefinitionUrls` no longer drops external URLs (this collection only feeds the batch resolver).
- `resolveAuthoritativeDefinition` resolves cache misses through the batch endpoint rather than a direct GET, so external/IRI references resolve too.
- `getDefinition`, `useInheritedDefinition`, and the property details panel defer the host decision to the resolver instead of short-circuiting on external URLs.

Also removes leftover debug `console.log`s in the property panel and an unused render-prop binding.

## Screenshots

Omitted: the affected behavior is embedded-mode only (it requires a host that configures `semantics.batchResolveUrl`), so it can't be exercised from the standalone dev server. Verified in a downstream embedding — a property linked to a concept by its IRI now renders the inherited values and the "Show details" popover, where before both were blank.

## Testing

`authoritativeDefinitions.test.js` and `authoritativeDefinitionsSlice.test.js` updated and extended (external/IRI URLs are now collected; the lazy path resolves via the batch endpoint; external URLs resolve in batch mode but return `null` without a resolver). 19 tests pass; `eslint` clean; `npm run build` succeeds.