### PR TITLE
Localize status dropdown options and fix combobox selected-value display

### DIFF
--- a/src/components/ui/Combobox.jsx
+++ b/src/components/ui/Combobox.jsx
@@ -81,7 +81,17 @@ const ComboboxComponent = ({
           className={`block w-full rounded-md border-0 py-1.5 ${renderSelectedIcon && value ? 'pl-9' : 'pl-2'} pr-8 text-gray-900 bg-white shadow-sm ring-1 ring-inset ${hasError ? 'ring-red-300 focus:ring-red-500' : 'ring-gray-300 focus:ring-indigo-600'} placeholder:text-gray-400 focus:ring-2 focus:ring-inset disabled:bg-gray-50 disabled:text-gray-500 disabled:ring-gray-200 text-xs leading-4`}
           onChange={handleInputChange}
           onBlur={() => setQuery('')}
-          displayValue={acceptAnyInput ? (item) => item || '' : displayValue}
+          displayValue={acceptAnyInput
+            ? (item) => {
+                // Map a stored canonical value (e.g. 'active') to its localized
+                // option label (e.g. 'Aktiv'); fall back to the raw value for
+                // custom/free-text entries that don't match any option.
+                const match = options.find(
+                  (o) => (o?.id ?? o?.value ?? o?.name ?? o) === item
+                );
+                return match ? displayValue(match) : (item || '');
+              }
+            : displayValue}
           placeholder={placeholder || t('input.selectOption')}
         />
         <ComboboxButton className="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-hidden">
@@ -106,7 +116,7 @@ const ComboboxComponent = ({
           {filteredOptions.length > 0 && filteredOptions.map((option, index) => (
             <ComboboxOption
               key={option.id || option.value || index}
-              value={acceptAnyInput ? (option[filterKey] || option.name || option.label || option) : option}
+              value={acceptAnyInput ? (option.id ?? option.value ?? option.name ?? option.label ?? option) : option}
               className="cursor-default px-3 py-2 text-gray-900 select-none data-focus:bg-indigo-600 data-focus:text-white data-focus:outline-hidden"
             >
               {renderOption ? (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -35,7 +35,15 @@
     "status": {
       "label": "Status",
       "placeholder": "Status auswählen...",
-      "tooltip": "Aktueller Status des Data Contracts"
+      "tooltip": "Aktueller Status des Data Contracts",
+      "options": {
+        "draft": "Entwurf",
+        "proposed": "Vorgeschlagen",
+        "inDevelopment": "In Entwicklung",
+        "active": "Aktiv",
+        "deprecated": "Veraltet",
+        "retired": "Außer Betrieb"
+      }
     },
     "tenant": {
       "label": "Tenant",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -46,8 +46,8 @@
       }
     },
     "tenant": {
-      "label": "Tenant",
-      "tooltip": "Tenant oder Organisation, zu der dieser Data Contract gehört"
+      "label": "Mandant",
+      "tooltip": "Mandant oder Organisation, zu der dieser Data Contract gehört"
     },
     "domain": {
       "label": "Domain",
@@ -1096,7 +1096,7 @@
       "version": "Version",
       "id": "ID",
       "status": "Status",
-      "tenant": "Tenant",
+      "tenant": "Mandant",
       "domain": "Domain",
       "dataProduct": "Data Product",
       "contractCreated": "Contract erstellt",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -35,7 +35,15 @@
     "status": {
       "label": "Status",
       "placeholder": "Select a status...",
-      "tooltip": "Current status of the data contract"
+      "tooltip": "Current status of the data contract",
+      "options": {
+        "draft": "draft",
+        "proposed": "proposed",
+        "inDevelopment": "in development",
+        "active": "active",
+        "deprecated": "deprecated",
+        "retired": "retired"
+      }
     },
     "tenant": {
       "label": "Tenant",

--- a/src/routes/Overview.jsx
+++ b/src/routes/Overview.jsx
@@ -63,12 +63,12 @@ const Overview = () => {
 
 	// Default status options (can be overridden by customization)
 	const defaultStatusOptions = [
-		{ id: 'draft', name: 'draft' },
-		{ id: 'proposed', name: 'proposed' },
-		{ id: 'in development', name: 'in development' },
-		{ id: 'active', name: 'active' },
-		{ id: 'deprecated', name: 'deprecated' },
-		{ id: 'retired', name: 'retired' }
+		{ id: 'draft', name: t('overview.status.options.draft') },
+		{ id: 'proposed', name: t('overview.status.options.proposed') },
+		{ id: 'in development', name: t('overview.status.options.inDevelopment') },
+		{ id: 'active', name: t('overview.status.options.active') },
+		{ id: 'deprecated', name: t('overview.status.options.deprecated') },
+		{ id: 'retired', name: t('overview.status.options.retired') }
 	];
 
 	// Apply status override


### PR DESCRIPTION
## Summary

Two small, independent improvements:

- **Localize status dropdown option labels.** The Overview status filter options were hardcoded English strings; they now resolve through the i18n layer (`en.json` / `de.json`) so they translate with the rest of the UI.
- **Fix combobox selected-value display for id/label options.** When a `Combobox` is given `{ id, label }` options, the selected value now shows its label instead of falling back to the raw id.