### PR TITLE
Custom properties: typed arrays, object YAML editor, and type-change guard

### DIFF
--- a/src/components/features/code/YamlEditor.jsx
+++ b/src/components/features/code/YamlEditor.jsx
@@ -185,7 +185,10 @@ const YamlEditor = forwardRef(({ schemaUrl }, ref) => {
                     schemas: [
                         {
                             uri: schemaUrl || 'http://myserver/schema.json',
-                            fileMatch: ['*'],
+                            // Scope validation to the main contract model so standalone
+                            // YAML editors (e.g. custom-property object editors) are not
+                            // validated against the ODCS schema.
+                            fileMatch: ['datacontract.yaml'],
                             schema
                         }
                     ]
@@ -373,6 +376,7 @@ const YamlEditor = forwardRef(({ schemaUrl }, ref) => {
                     <Editor
                         height="100%"
                         language="yaml"
+                        path="datacontract.yaml"
                         value={editorYaml || '# Enter your YAML here\n'}
                         onChange={handleChange}
                         onMount={handleEditorDidMount}

--- a/src/components/ui/CustomPropertiesEditor.jsx
+++ b/src/components/ui/CustomPropertiesEditor.jsx
@@ -3,6 +3,22 @@ import { useTranslation } from 'react-i18next';
 import CustomPropertyIcon from './icons/CustomPropertyIcon.jsx';
 import ChevronRightIcon from './icons/ChevronRightIcon.jsx';
 import TypedArrayEditor from './TypedArrayEditor.jsx';
+import ObjectYamlEditor from './ObjectYamlEditor.jsx';
+import TypeChangeWarning from './TypeChangeWarning.jsx';
+import { usePendingTypeChange } from '../../hooks/usePendingTypeChange.js';
+
+// A value is "empty" when there is nothing to lose by changing its type.
+const isEmptyValue = (val) =>
+  val === null ||
+  val === undefined ||
+  val === '' ||
+  (Array.isArray(val) && val.length === 0) ||
+  (typeof val === 'object' && !Array.isArray(val) && Object.keys(val).length === 0);
+
+// Changing a custom-property value type is destructive when the current value holds
+// content that the new type cannot carry over. Any target other than "string" (which
+// simply stringifies the current value) resets the field to an empty default.
+const isDestructiveTypeChange = (val, newType) => !isEmptyValue(val) && newType !== 'string';
 
 /**
  * CustomPropertiesEditor component for editing custom properties
@@ -88,10 +104,9 @@ const CustomPropertiesEditor = ({ value, onChange, showDescription = false, mana
 const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }) => {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(!item.property);
-  const [editingType, setEditingType] = useState(false);
 
   const inputClasses = "w-full rounded border border-gray-300 bg-white px-2 py-1 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs";
-  const selectClasses = "rounded border border-gray-300 bg-white px-1 py-0.5 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs text-gray-500";
+  const selectClasses = "rounded border border-gray-300 bg-white px-1 py-0.5 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs text-gray-600";
 
   // Detect value type from actual value
   const detectType = (val) => {
@@ -103,19 +118,16 @@ const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }
     return 'string';
   };
 
-  // Convert string input to typed value
+  // Convert a text input into the typed scalar value. Array and object values are edited
+  // by dedicated components (TypedArrayEditor / ObjectYamlEditor), so only the scalar
+  // types flow through here.
   const convertValue = (strVal, type) => {
-    if (type === 'string') return strVal;
     if (type === 'number') {
       const num = parseFloat(strVal);
       return isNaN(num) ? 0 : num;
     }
     if (type === 'boolean') {
       return strVal === 'true';
-    }
-    if (type === 'array' || type === 'object') {
-      // Store the raw string value directly without parsing
-      return strVal;
     }
     return strVal;
   };
@@ -140,7 +152,7 @@ const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }
     return val?.toString() || '';
   };
 
-  const handleTypeChange = (newType) => {
+  const applyTypeChange = (newType) => {
     const currentType = detectType(item.value);
     if (currentType === newType) return;
 
@@ -159,6 +171,10 @@ const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }
 
     onUpdate(index, 'value', newValue);
   };
+
+  // Confirm destructive type changes before they clear the current value.
+  const { pendingType, request: requestTypeChange, confirm: confirmTypeChange, cancel: cancelTypeChange } =
+    usePendingTypeChange(applyTypeChange);
 
   const handleValueChange = (strVal, type) => {
     const converted = convertValue(strVal, type);
@@ -247,36 +263,28 @@ const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }
           </div>
 
           {/* Value field (below the property) */}
-          <div>
-            <div className="flex items-center gap-1 h-6">
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5 h-6">
               <label className="text-xs font-medium text-gray-700">{t('customProperty.value.label')}</label>
-              {editingType ? (
-                <select
-                  value={type}
-                  onChange={(e) => {
-                    handleTypeChange(e.target.value);
-                    setEditingType(false);
-                  }}
-                  onBlur={() => setEditingType(false)}
-                  autoFocus
-                  className={selectClasses}
-                >
-                  <option value="string">string</option>
-                  <option value="number">number</option>
-                  <option value="boolean">boolean</option>
-                  <option value="array">array</option>
-                  <option value="object">object</option>
-                </select>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingType(true)}
-                  className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer"
-                >
-                  ({type})
-                </button>
-              )}
+              <select
+                value={type}
+                onChange={(e) => requestTypeChange(e.target.value, isDestructiveTypeChange(item.value, e.target.value))}
+                className={selectClasses}
+              >
+                <option value="string">string</option>
+                <option value="number">number</option>
+                <option value="boolean">boolean</option>
+                <option value="array">array</option>
+                <option value="object">object</option>
+              </select>
             </div>
+            {pendingType && (
+              <TypeChangeWarning
+                targetType={pendingType}
+                onConfirm={confirmTypeChange}
+                onCancel={cancelTypeChange}
+              />
+            )}
             {type === 'boolean' ? (
               <select
                 value={item.value === true ? 'true' : item.value === false ? 'false' : ''}
@@ -301,12 +309,10 @@ const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }
                 onChange={(val) => onUpdate(index, 'value', val)}
               />
             ) : type === 'object' ? (
-              <input
-                type="text"
-                value={getValueString(item.value, type)}
-                onChange={(e) => handleValueChange(e.target.value, type)}
-                className={`${inputClasses} font-mono`}
-                placeholder='{"key": "value"}'
+              <ObjectYamlEditor
+                kind="object"
+                value={item.value && typeof item.value === 'object' && !Array.isArray(item.value) ? item.value : {}}
+                onChange={(val) => onUpdate(index, 'value', val)}
               />
             ) : (
               <input

--- a/src/components/ui/CustomPropertiesEditor.jsx
+++ b/src/components/ui/CustomPropertiesEditor.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import CustomPropertyIcon from './icons/CustomPropertyIcon.jsx';
 import ChevronRightIcon from './icons/ChevronRightIcon.jsx';
+import TypedArrayEditor from './TypedArrayEditor.jsx';
 
 /**
  * CustomPropertiesEditor component for editing custom properties
@@ -221,9 +222,9 @@ const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }
       {/* Expandable content */}
       {isExpanded && (
         <div className="border-t border-gray-200 px-3 py-3 space-y-3">
-          {/* Property, Value, and Remove button in one line */}
-          <div className="grid grid-cols-12 gap-2 items-end">
-            <div className="col-span-4">
+          {/* Property field with remove button */}
+          <div className="flex items-end gap-2">
+            <div className="flex-1 min-w-0">
               <label className="block text-xs font-medium text-gray-700 mb-1">{t('customProperty.property.label')}</label>
               <input
                 type="text"
@@ -233,82 +234,89 @@ const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }
                 placeholder="myCustomProperty"
               />
             </div>
-            <div className="col-span-7">
-              <div className="flex items-center gap-1 h-6">
-                <label className="text-xs font-medium text-gray-700">{t('customProperty.value.label')}</label>
-                {editingType ? (
-                  <select
-                    value={type}
-                    onChange={(e) => {
-                      handleTypeChange(e.target.value);
-                      setEditingType(false);
-                    }}
-                    onBlur={() => setEditingType(false)}
-                    autoFocus
-                    className={selectClasses}
-                  >
-                    <option value="string">string</option>
-                    <option value="number">number</option>
-                    <option value="boolean">boolean</option>
-                    <option value="array">array</option>
-                    <option value="object">object</option>
-                  </select>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => setEditingType(true)}
-                    className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer"
-                  >
-                    ({type})
-                  </button>
-                )}
-              </div>
-              {type === 'boolean' ? (
-                <select
-                  value={item.value === true ? 'true' : item.value === false ? 'false' : ''}
-                  onChange={(e) => handleValueChange(e.target.value, 'boolean')}
-                  className={inputClasses}
-                >
-                  <option value="false">false</option>
-                  <option value="true">true</option>
-                </select>
-              ) : type === 'number' ? (
-                <input
-                  type="number"
-                  step="any"
-                  value={item.value ?? ''}
-                  onChange={(e) => handleValueChange(e.target.value, 'number')}
-                  className={inputClasses}
-                  placeholder="0"
-                />
-              ) : type === 'array' || type === 'object' ? (
-                <input
-                  type="text"
-                  value={getValueString(item.value, type)}
-                  onChange={(e) => handleValueChange(e.target.value, type)}
-                  className={`${inputClasses} font-mono`}
-                  placeholder={type === 'array' ? '["item1", "item2"]' : '{"key": "value"}'}
-                />
-              ) : (
-                <input
-                  type="text"
-                  value={getValueString(item.value, type)}
-                  onChange={(e) => handleValueChange(e.target.value, type)}
-                  className={inputClasses}
-                  placeholder={t('customProperty.value.placeholder')}
-                />
-              )}
-            </div>
             <button
               type="button"
               onClick={() => onRemove(index)}
-              className="p-1 text-gray-400 cursor-pointer border border-gray-300 rounded hover:text-red-400 hover:border-red-400 transition-colors justify-self-end"
+              className="p-1 text-gray-400 cursor-pointer border border-gray-300 rounded hover:text-red-400 hover:border-red-400 transition-colors shrink-0"
               title={t('customProperty.remove')}
             >
               <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
               </svg>
             </button>
+          </div>
+
+          {/* Value field (below the property) */}
+          <div>
+            <div className="flex items-center gap-1 h-6">
+              <label className="text-xs font-medium text-gray-700">{t('customProperty.value.label')}</label>
+              {editingType ? (
+                <select
+                  value={type}
+                  onChange={(e) => {
+                    handleTypeChange(e.target.value);
+                    setEditingType(false);
+                  }}
+                  onBlur={() => setEditingType(false)}
+                  autoFocus
+                  className={selectClasses}
+                >
+                  <option value="string">string</option>
+                  <option value="number">number</option>
+                  <option value="boolean">boolean</option>
+                  <option value="array">array</option>
+                  <option value="object">object</option>
+                </select>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditingType(true)}
+                  className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer"
+                >
+                  ({type})
+                </button>
+              )}
+            </div>
+            {type === 'boolean' ? (
+              <select
+                value={item.value === true ? 'true' : item.value === false ? 'false' : ''}
+                onChange={(e) => handleValueChange(e.target.value, 'boolean')}
+                className={inputClasses}
+              >
+                <option value="false">false</option>
+                <option value="true">true</option>
+              </select>
+            ) : type === 'number' ? (
+              <input
+                type="number"
+                step="any"
+                value={item.value ?? ''}
+                onChange={(e) => handleValueChange(e.target.value, 'number')}
+                className={inputClasses}
+                placeholder="0"
+              />
+            ) : type === 'array' ? (
+              <TypedArrayEditor
+                value={Array.isArray(item.value) ? item.value : []}
+                onChange={(val) => onUpdate(index, 'value', val)}
+              />
+            ) : type === 'object' ? (
+              <input
+                type="text"
+                value={getValueString(item.value, type)}
+                onChange={(e) => handleValueChange(e.target.value, type)}
+                className={`${inputClasses} font-mono`}
+                placeholder='{"key": "value"}'
+              />
+            ) : (
+              <input
+                type="text"
+                value={getValueString(item.value, type)}
+                onChange={(e) => handleValueChange(e.target.value, type)}
+                className={inputClasses}
+                placeholder={t('customProperty.value.placeholder')}
+              />
+            )}
           </div>
 
           {/* Description field (optional) */}
@@ -320,7 +328,7 @@ const CustomPropertyCard = ({ item, index, showDescription, onUpdate, onRemove }
                 onChange={(e) => onUpdate(index, 'description', e.target.value)}
                 className={inputClasses}
                 placeholder={t('customProperty.description.placeholder')}
-                rows={2}
+                rows={1}
               />
             </div>
           )}

--- a/src/components/ui/ObjectYamlEditor.jsx
+++ b/src/components/ui/ObjectYamlEditor.jsx
@@ -1,0 +1,150 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import Editor from '@monaco-editor/react';
+import { useTranslation } from 'react-i18next';
+import { conf as yamlConf, language as yamlTokens } from 'monaco-editor/esm/vs/basic-languages/yaml/yaml.js';
+import { monaco } from '../../lib/monaco-workers.js';
+import { parseYaml, stringifyYaml } from '../../utils/yaml.js';
+
+// A dedicated YAML language for free-form value editing. It reuses YAML syntax
+// highlighting but is a distinct language id, so none of the data-contract completion
+// providers registered on the built-in "yaml" language (monaco-yaml, ODCS schema) apply
+// here — no schema suggestions, no "Inline schema" item, no empty "No suggestions" popup.
+const OBJECT_YAML_LANGUAGE = 'object-yaml';
+if (monaco?.languages && !monaco.languages.getLanguages().some((l) => l.id === OBJECT_YAML_LANGUAGE)) {
+  monaco.languages.register({ id: OBJECT_YAML_LANGUAGE });
+  monaco.languages.setLanguageConfiguration(OBJECT_YAML_LANGUAGE, yamlConf);
+  monaco.languages.setMonarchTokensProvider(OBJECT_YAML_LANGUAGE, yamlTokens);
+}
+
+/**
+ * ObjectYamlEditor edits an object (or an array of objects) as free-form YAML using
+ * Monaco, with syntax highlighting. It keeps local text so partially-typed / temporarily
+ * invalid YAML is not clobbered, parses on every change, and only propagates a valid
+ * value of the expected shape. Invalid input shows an inline error and leaves the last
+ * valid value untouched.
+ *
+ * @param {object|Array} value - The current object or array value
+ * @param {Function} onChange - Called with the parsed value when it is valid
+ * @param {'object'|'array'} kind - Whether the value is a single object or an array
+ * @param {number} height - Editor height in pixels
+ */
+const emptyFor = (kind) => (kind === 'array' ? [] : {});
+
+const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+const toYaml = (value, kind) => {
+  const v = value == null ? emptyFor(kind) : value;
+  // Start empty for empty values so the editor is a clean slate to type into.
+  if (kind === 'array' && Array.isArray(v) && v.length === 0) return '';
+  if (kind === 'object' && isPlainObject(v) && Object.keys(v).length === 0) return '';
+  try {
+    return stringifyYaml(v).replace(/\n$/, '');
+  } catch {
+    return '';
+  }
+};
+
+const ObjectYamlEditor = ({ value, onChange, kind = 'object', height = 180 }) => {
+  const { t } = useTranslation();
+  const [text, setText] = useState(() => toYaml(value, kind));
+  const [error, setError] = useState(null);
+  const focusedRef = useRef(false);
+
+  // A unique model path per instance keeps this editor out of the main contract
+  // schema's fileMatch, so custom object/array YAML is edited freely without ODCS
+  // schema validation squiggles.
+  const path = `custom-property-${useId().replace(/[^a-zA-Z0-9]/g, '')}.yaml`;
+
+  // Resync from the value when it changes externally (undo, type switch) and the user
+  // is not actively editing — otherwise in-progress text would be clobbered.
+  useEffect(() => {
+    if (!focusedRef.current) {
+      setText(toYaml(value, kind));
+      setError(null);
+    }
+  }, [value, kind]);
+
+  const handleChange = (next) => {
+    const nextText = next ?? '';
+    setText(nextText);
+
+    if (nextText.trim() === '') {
+      setError(null);
+      onChange(emptyFor(kind));
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = parseYaml(nextText);
+    } catch (e) {
+      setError(t('customProperty.yaml.invalid', { message: e.message || 'parse error' }));
+      return;
+    }
+
+    if (kind === 'array') {
+      if (!Array.isArray(parsed)) {
+        setError(t('customProperty.yaml.expectedArray'));
+        return;
+      }
+    } else if (!isPlainObject(parsed)) {
+      setError(t('customProperty.yaml.expectedObject'));
+      return;
+    }
+
+    setError(null);
+    onChange(parsed);
+  };
+
+  const handleMount = (editor, monacoInstance) => {
+    editor.onDidFocusEditorText(() => {
+      focusedRef.current = true;
+    });
+    editor.onDidBlurEditorText(() => {
+      focusedRef.current = false;
+    });
+    // Swallow the manual "trigger suggestions" shortcut so the empty suggest widget
+    // ("No suggestions.") never appears in this free-form editor.
+    const noop = () => {};
+    editor.addCommand(monacoInstance.KeyMod.CtrlCmd | monacoInstance.KeyCode.Space, noop);
+    editor.addCommand(monacoInstance.KeyMod.WinCtrl | monacoInstance.KeyCode.Space, noop);
+  };
+
+  return (
+    <div className={`rounded border overflow-hidden ${error ? 'border-red-400' : 'border-gray-300'}`}>
+      <Editor
+        height={height}
+        language={OBJECT_YAML_LANGUAGE}
+        path={path}
+        value={text}
+        onChange={handleChange}
+        onMount={handleMount}
+        theme="vs-light"
+        options={{
+          minimap: { enabled: false },
+          scrollBeyondLastLine: false,
+          fontSize: 12,
+          wordWrap: 'on',
+          automaticLayout: true,
+          tabSize: 2,
+          insertSpaces: true,
+          lineNumbers: 'on',
+          folding: true,
+          stickyScroll: { enabled: false },
+          scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 },
+          // This is free-form YAML, not a data contract — suppress the ODCS schema
+          // completions that the global YAML providers would otherwise offer here.
+          quickSuggestions: false,
+          suggestOnTriggerCharacters: false,
+          wordBasedSuggestions: 'off',
+          parameterHints: { enabled: false },
+        }}
+      />
+      {error && (
+        <div className="px-2 py-1 text-xs text-red-600 bg-red-50 border-t border-red-200">{error}</div>
+      )}
+    </div>
+  );
+};
+
+export default ObjectYamlEditor;

--- a/src/components/ui/TypeChangeWarning.jsx
+++ b/src/components/ui/TypeChangeWarning.jsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Inline confirmation shown before a destructive type change that would clear the
+ * current value. The caller keeps the change pending until onConfirm is invoked.
+ *
+ * @param {string} targetType - The type being switched to (shown in the message)
+ * @param {Function} onConfirm - Apply the type change
+ * @param {Function} onCancel - Dismiss without changing the type
+ */
+const TypeChangeWarning = ({ targetType, onConfirm, onCancel }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded border border-amber-300 bg-amber-50 px-2 py-1.5 text-xs text-amber-800">
+      <div className="flex items-start gap-1.5">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-3.5 w-3.5 shrink-0 mt-0.5 text-amber-500"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+            clipRule="evenodd"
+          />
+        </svg>
+        <span>{t('customProperty.typeChangeWarning.message', { type: targetType })}</span>
+      </div>
+      <div className="mt-1.5 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="rounded bg-amber-600 px-2 py-0.5 text-xs font-medium text-white hover:bg-amber-700"
+        >
+          {t('customProperty.typeChangeWarning.confirm')}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-xs font-medium text-gray-600 hover:text-gray-800"
+        >
+          {t('customProperty.typeChangeWarning.cancel')}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TypeChangeWarning;

--- a/src/components/ui/TypedArrayEditor.jsx
+++ b/src/components/ui/TypedArrayEditor.jsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import ObjectYamlEditor from './ObjectYamlEditor.jsx';
+import TypeChangeWarning from './TypeChangeWarning.jsx';
+import { usePendingTypeChange } from '../../hooks/usePendingTypeChange.js';
 
 /**
  * TypedArrayEditor edits an array whose elements are all the same primitive/object type.
@@ -39,15 +42,14 @@ const coerceObject = (item) => {
 };
 
 const defaultRow = (type) => {
-  if (type === 'boolean') return false;
   if (type === 'object') return {};
-  return ''; // string and number both start as empty text
+  return ''; // string/number start as empty text; boolean starts unset ('')
 };
 
 // Convert an actual array value into a raw editing row for the given element type.
 const toRow = (item, type) => {
   if (type === 'number') return item === null || item === undefined || item === '' ? '' : String(item);
-  if (type === 'boolean') return item === true;
+  if (type === 'boolean') return item === true ? true : item === false ? false : ''; // '' = unset
   if (type === 'object') return coerceObject(item);
   if (item === null || item === undefined) return '';
   if (typeof item === 'object') {
@@ -60,14 +62,15 @@ const toRow = (item, type) => {
   return String(item);
 };
 
-// Derive the actual array from the editing rows. Empty number rows are dropped.
+// Derive the actual array from the editing rows. Empty number rows and unset boolean rows
+// are dropped, so an untouched auto-added first row leaves the stored value empty.
 const rowsToArray = (rows, type) => {
   if (type === 'number') {
     return rows
       .map((r) => (String(r).trim() === '' ? null : parseFloat(r)))
       .filter((n) => n !== null && !isNaN(n));
   }
-  if (type === 'boolean') return rows.map((r) => r === true);
+  if (type === 'boolean') return rows.filter((r) => r === true || r === false);
   if (type === 'object') return rows.map((r) => coerceObject(r));
   return rows.map((r) => (r === null || r === undefined ? '' : String(r)));
 };
@@ -80,6 +83,23 @@ const sameArray = (a, b) => {
   }
 };
 
+const hasContent = (v) =>
+  !(v === '' || v === null || v === undefined ||
+    (typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0));
+
+// Changing the element type is destructive when existing items with content cannot be
+// carried over: converting to "string" always stringifies (safe), but object<->scalar or
+// a conversion that drops items (e.g. non-numeric strings -> number) clears content.
+// Empty items (e.g. the auto-added first row) carry nothing, so they never warn.
+const isDestructiveElementChange = (currentRows, fromType, toType) => {
+  const values = rowsToArray(currentRows, fromType).filter(hasContent);
+  if (values.length === 0) return false;
+  if (toType === 'string') return false;
+  if (fromType === 'object' || toType === 'object') return true;
+  const after = rowsToArray(values.map((v) => toRow(v, toType)), toType);
+  return after.length < values.length;
+};
+
 const TypedArrayEditor = ({ value = [], onChange }) => {
   const { t } = useTranslation();
   const externalArray = Array.isArray(value) ? value : [];
@@ -89,7 +109,14 @@ const TypedArrayEditor = ({ value = [], onChange }) => {
   // Detected type wins when the array has items, otherwise use the selected type.
   const type = detected || elementType;
 
-  const [rows, setRows] = useState(() => externalArray.map((it) => toRow(it, detected || 'string')));
+  // Show at least one row so an empty array (e.g. right after switching to the array type)
+  // presents an element to edit. The empty row is local only — it is not written back until
+  // the user gives it content.
+  const withMinRow = (nextRows) => (nextRows.length ? nextRows : [defaultRow(type)]);
+
+  const [rows, setRows] = useState(() =>
+    withMinRow(externalArray.map((it) => toRow(it, detected || 'string')))
+  );
   const rowsRef = useRef(rows);
   rowsRef.current = rows;
 
@@ -97,7 +124,7 @@ const TypedArrayEditor = ({ value = [], onChange }) => {
   // echo of our own onChange — otherwise an in-progress empty row would be wiped.
   useEffect(() => {
     if (!sameArray(rowsToArray(rowsRef.current, type), externalArray)) {
-      setRows(externalArray.map((it) => toRow(it, type)));
+      setRows(withMinRow(externalArray.map((it) => toRow(it, type))));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
@@ -110,12 +137,16 @@ const TypedArrayEditor = ({ value = [], onChange }) => {
     onChange(rowsToArray(nextRows, forType));
   };
 
-  const handleTypeChange = (newType) => {
+  const applyTypeChange = (newType) => {
     const values = rowsToArray(rows, type);
     const newRows = values.map((v) => toRow(v, newType));
     setElementType(newType);
     commit(newRows, newType);
   };
+
+  // Confirm destructive element-type changes before they clear existing items.
+  const { pendingType, request: requestTypeChange, confirm: confirmTypeChange, cancel: cancelTypeChange } =
+    usePendingTypeChange(applyTypeChange);
 
   const handleAdd = () => {
     commit([...rows, defaultRow(type)]);
@@ -132,13 +163,13 @@ const TypedArrayEditor = ({ value = [], onChange }) => {
   };
 
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2">
       {/* Element type selector */}
       <div className="flex items-center gap-2">
         <label className="text-xs text-gray-500">{t('customProperty.arrayItemType')}</label>
         <select
           value={type}
-          onChange={(e) => handleTypeChange(e.target.value)}
+          onChange={(e) => requestTypeChange(e.target.value, isDestructiveElementChange(rows, type, e.target.value))}
           className="rounded border border-gray-300 bg-white px-1 py-0.5 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs text-gray-600"
         >
           {ELEMENT_TYPES.map((et) => (
@@ -149,127 +180,90 @@ const TypedArrayEditor = ({ value = [], onChange }) => {
         </select>
       </div>
 
-      {/* Existing items */}
-      {rows.length > 0 && (
-        <div className="space-y-1">
-          {rows.map((row, index) => (
-            <div key={`${type}-${index}`} className="flex items-start gap-1">
-              {type === 'number' ? (
-                <input
-                  type="number"
-                  step="any"
-                  value={row}
-                  onChange={(e) => handleUpdate(index, e.target.value)}
-                  className={inputClasses}
-                  placeholder="0"
-                />
-              ) : type === 'boolean' ? (
-                <select
-                  value={row === true ? 'true' : 'false'}
-                  onChange={(e) => handleUpdate(index, e.target.value === 'true')}
-                  className={inputClasses}
-                >
-                  <option value="false">false</option>
-                  <option value="true">true</option>
-                </select>
-              ) : type === 'object' ? (
-                <ObjectItemInput
-                  value={row}
-                  onChange={(val) => handleUpdate(index, val)}
-                  className={`${inputClasses} font-mono`}
-                />
-              ) : (
-                <input
-                  type="text"
-                  value={row}
-                  onChange={(e) => handleUpdate(index, e.target.value)}
-                  className={inputClasses}
-                  placeholder={t('arrayInput.placeholder')}
-                />
-              )}
-              <button
-                type="button"
-                onClick={() => handleRemove(index)}
-                className="p-1 text-gray-400 cursor-pointer border border-gray-300 rounded hover:text-red-400 hover:border-red-400 transition-colors shrink-0"
-                title={t('arrayInput.remove')}
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-3.5 w-3.5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-          ))}
-        </div>
+      {pendingType && (
+        <TypeChangeWarning
+          targetType={pendingType}
+          onConfirm={confirmTypeChange}
+          onCancel={cancelTypeChange}
+        />
       )}
 
-      {/* Add button */}
-      <button
-        type="button"
-        onClick={handleAdd}
-        className="text-xs text-indigo-600 hover:text-indigo-700 font-medium"
-      >
-        + {t('arrayInput.add')}
-      </button>
+      {type === 'object' ? (
+        /* Whole array edited as free-form YAML */
+        <ObjectYamlEditor
+          kind="array"
+          value={rowsToArray(rows, 'object')}
+          onChange={(arr) => commit(arr.map((it) => toRow(it, 'object')), 'object')}
+        />
+      ) : (
+        <>
+          {/* Existing items */}
+          {rows.length > 0 && (
+            <div className="space-y-1.5">
+              {rows.map((row, index) => (
+                <div key={`${type}-${index}`} className="flex items-start gap-1">
+                  {type === 'number' ? (
+                    <input
+                      type="number"
+                      step="any"
+                      value={row}
+                      onChange={(e) => handleUpdate(index, e.target.value)}
+                      className={inputClasses}
+                      placeholder="0"
+                    />
+                  ) : type === 'boolean' ? (
+                    <select
+                      value={row === true ? 'true' : row === false ? 'false' : ''}
+                      onChange={(e) =>
+                        handleUpdate(index, e.target.value === '' ? '' : e.target.value === 'true')
+                      }
+                      className={inputClasses}
+                    >
+                      <option value="">{t('customProperty.boolean.notSet')}</option>
+                      <option value="false">false</option>
+                      <option value="true">true</option>
+                    </select>
+                  ) : (
+                    <input
+                      type="text"
+                      value={row}
+                      onChange={(e) => handleUpdate(index, e.target.value)}
+                      className={inputClasses}
+                      placeholder={t('arrayInput.placeholder')}
+                    />
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(index)}
+                    className="p-1 text-gray-400 cursor-pointer border border-gray-300 rounded hover:text-red-400 hover:border-red-400 transition-colors shrink-0"
+                    title={t('arrayInput.remove')}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-3.5 w-3.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Add button */}
+          <button
+            type="button"
+            onClick={handleAdd}
+            className="text-xs text-indigo-600 hover:text-indigo-700 font-medium"
+          >
+            + {t('arrayInput.add')}
+          </button>
+        </>
+      )}
     </div>
-  );
-};
-
-/**
- * ObjectItemInput edits a single object array element as JSON, keeping local text
- * state so partially-typed (temporarily invalid) JSON is not clobbered on every keystroke.
- */
-const ObjectItemInput = ({ value, onChange, className }) => {
-  const stringify = (val) => {
-    try {
-      return JSON.stringify(val ?? {}, null, 2);
-    } catch {
-      return '{}';
-    }
-  };
-
-  const [text, setText] = useState(() => stringify(value));
-  const [error, setError] = useState(false);
-
-  // Sync when the value changes externally (e.g. type conversion) while not focused.
-  const [focused, setFocused] = useState(false);
-  useEffect(() => {
-    if (!focused) {
-      setText(stringify(value));
-      setError(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
-
-  const handleChange = (e) => {
-    const next = e.target.value;
-    setText(next);
-    try {
-      const parsed = JSON.parse(next);
-      setError(false);
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        onChange(parsed);
-      }
-    } catch {
-      setError(true);
-    }
-  };
-
-  return (
-    <textarea
-      value={text}
-      onChange={handleChange}
-      onFocus={() => setFocused(true)}
-      onBlur={() => setFocused(false)}
-      rows={2}
-      className={`${className} ${error ? 'border-red-400 focus:border-red-400 focus:ring-red-400' : ''}`}
-      placeholder='{"key": "value"}'
-    />
   );
 };
 

--- a/src/components/ui/TypedArrayEditor.jsx
+++ b/src/components/ui/TypedArrayEditor.jsx
@@ -1,0 +1,276 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * TypedArrayEditor edits an array whose elements are all the same primitive/object type.
+ * The element type (string, number, boolean, or object) can be selected, and items are
+ * added, edited, and removed inline in the style of ArrayInput.
+ *
+ * Local "rows" hold the raw editing state (e.g. number rows keep the typed text so a
+ * partially-typed or empty field is not clobbered). The emitted array is derived from the
+ * rows: for numbers, empty rows are simply left out of the array.
+ *
+ * @param {Array} value - The array being edited (actual JS array, not a string)
+ * @param {Function} onChange - Callback with the updated array
+ */
+const ELEMENT_TYPES = ['string', 'number', 'boolean', 'object'];
+
+const detectElementType = (arr) => {
+  if (!Array.isArray(arr)) return null;
+  const first = arr.find((v) => v !== null && v !== undefined);
+  if (first === undefined) return null;
+  if (typeof first === 'boolean') return 'boolean';
+  if (typeof first === 'number') return 'number';
+  if (typeof first === 'object') return 'object';
+  return 'string';
+};
+
+const coerceObject = (item) => {
+  if (item && typeof item === 'object' && !Array.isArray(item)) return item;
+  if (typeof item === 'string') {
+    try {
+      const parsed = JSON.parse(item);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+};
+
+const defaultRow = (type) => {
+  if (type === 'boolean') return false;
+  if (type === 'object') return {};
+  return ''; // string and number both start as empty text
+};
+
+// Convert an actual array value into a raw editing row for the given element type.
+const toRow = (item, type) => {
+  if (type === 'number') return item === null || item === undefined || item === '' ? '' : String(item);
+  if (type === 'boolean') return item === true;
+  if (type === 'object') return coerceObject(item);
+  if (item === null || item === undefined) return '';
+  if (typeof item === 'object') {
+    try {
+      return JSON.stringify(item);
+    } catch {
+      return '';
+    }
+  }
+  return String(item);
+};
+
+// Derive the actual array from the editing rows. Empty number rows are dropped.
+const rowsToArray = (rows, type) => {
+  if (type === 'number') {
+    return rows
+      .map((r) => (String(r).trim() === '' ? null : parseFloat(r)))
+      .filter((n) => n !== null && !isNaN(n));
+  }
+  if (type === 'boolean') return rows.map((r) => r === true);
+  if (type === 'object') return rows.map((r) => coerceObject(r));
+  return rows.map((r) => (r === null || r === undefined ? '' : String(r)));
+};
+
+const sameArray = (a, b) => {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+};
+
+const TypedArrayEditor = ({ value = [], onChange }) => {
+  const { t } = useTranslation();
+  const externalArray = Array.isArray(value) ? value : [];
+  const detected = detectElementType(externalArray);
+  const [elementType, setElementType] = useState(detected || 'string');
+
+  // Detected type wins when the array has items, otherwise use the selected type.
+  const type = detected || elementType;
+
+  const [rows, setRows] = useState(() => externalArray.map((it) => toRow(it, detected || 'string')));
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+
+  // Resync local rows when the value changes from outside (e.g. undo), but ignore the
+  // echo of our own onChange — otherwise an in-progress empty row would be wiped.
+  useEffect(() => {
+    if (!sameArray(rowsToArray(rowsRef.current, type), externalArray)) {
+      setRows(externalArray.map((it) => toRow(it, type)));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const inputClasses =
+    'flex-1 min-w-0 rounded border border-gray-300 bg-white px-2 py-1 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs';
+
+  const commit = (nextRows, forType = type) => {
+    setRows(nextRows);
+    onChange(rowsToArray(nextRows, forType));
+  };
+
+  const handleTypeChange = (newType) => {
+    const values = rowsToArray(rows, type);
+    const newRows = values.map((v) => toRow(v, newType));
+    setElementType(newType);
+    commit(newRows, newType);
+  };
+
+  const handleAdd = () => {
+    commit([...rows, defaultRow(type)]);
+  };
+
+  const handleUpdate = (index, rawVal) => {
+    const next = [...rows];
+    next[index] = rawVal;
+    commit(next);
+  };
+
+  const handleRemove = (index) => {
+    commit(rows.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-1.5">
+      {/* Element type selector */}
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-gray-500">{t('customProperty.arrayItemType')}</label>
+        <select
+          value={type}
+          onChange={(e) => handleTypeChange(e.target.value)}
+          className="rounded border border-gray-300 bg-white px-1 py-0.5 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs text-gray-600"
+        >
+          {ELEMENT_TYPES.map((et) => (
+            <option key={et} value={et}>
+              {et}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Existing items */}
+      {rows.length > 0 && (
+        <div className="space-y-1">
+          {rows.map((row, index) => (
+            <div key={`${type}-${index}`} className="flex items-start gap-1">
+              {type === 'number' ? (
+                <input
+                  type="number"
+                  step="any"
+                  value={row}
+                  onChange={(e) => handleUpdate(index, e.target.value)}
+                  className={inputClasses}
+                  placeholder="0"
+                />
+              ) : type === 'boolean' ? (
+                <select
+                  value={row === true ? 'true' : 'false'}
+                  onChange={(e) => handleUpdate(index, e.target.value === 'true')}
+                  className={inputClasses}
+                >
+                  <option value="false">false</option>
+                  <option value="true">true</option>
+                </select>
+              ) : type === 'object' ? (
+                <ObjectItemInput
+                  value={row}
+                  onChange={(val) => handleUpdate(index, val)}
+                  className={`${inputClasses} font-mono`}
+                />
+              ) : (
+                <input
+                  type="text"
+                  value={row}
+                  onChange={(e) => handleUpdate(index, e.target.value)}
+                  className={inputClasses}
+                  placeholder={t('arrayInput.placeholder')}
+                />
+              )}
+              <button
+                type="button"
+                onClick={() => handleRemove(index)}
+                className="p-1 text-gray-400 cursor-pointer border border-gray-300 rounded hover:text-red-400 hover:border-red-400 transition-colors shrink-0"
+                title={t('arrayInput.remove')}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-3.5 w-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add button */}
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="text-xs text-indigo-600 hover:text-indigo-700 font-medium"
+      >
+        + {t('arrayInput.add')}
+      </button>
+    </div>
+  );
+};
+
+/**
+ * ObjectItemInput edits a single object array element as JSON, keeping local text
+ * state so partially-typed (temporarily invalid) JSON is not clobbered on every keystroke.
+ */
+const ObjectItemInput = ({ value, onChange, className }) => {
+  const stringify = (val) => {
+    try {
+      return JSON.stringify(val ?? {}, null, 2);
+    } catch {
+      return '{}';
+    }
+  };
+
+  const [text, setText] = useState(() => stringify(value));
+  const [error, setError] = useState(false);
+
+  // Sync when the value changes externally (e.g. type conversion) while not focused.
+  const [focused, setFocused] = useState(false);
+  useEffect(() => {
+    if (!focused) {
+      setText(stringify(value));
+      setError(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const handleChange = (e) => {
+    const next = e.target.value;
+    setText(next);
+    try {
+      const parsed = JSON.parse(next);
+      setError(false);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        onChange(parsed);
+      }
+    } catch {
+      setError(true);
+    }
+  };
+
+  return (
+    <textarea
+      value={text}
+      onChange={handleChange}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+      rows={2}
+      className={`${className} ${error ? 'border-red-400 focus:border-red-400 focus:ring-red-400' : ''}`}
+      placeholder='{"key": "value"}'
+    />
+  );
+};
+
+export default TypedArrayEditor;

--- a/src/hooks/usePendingTypeChange.js
+++ b/src/hooks/usePendingTypeChange.js
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+/**
+ * Guards a value/element type change behind a confirmation when it is destructive.
+ * Non-destructive changes apply immediately; destructive ones are held as `pendingType`
+ * until `confirm()` is called (or dropped with `cancel()`).
+ *
+ * @param {(type: string) => void} applyChange - Applies the type change.
+ * @returns {{ pendingType: string|null, request: (type: string, destructive: boolean) => void, confirm: () => void, cancel: () => void }}
+ */
+export function usePendingTypeChange(applyChange) {
+  const [pendingType, setPendingType] = useState(null);
+
+  const request = (newType, isDestructive) => {
+    if (isDestructive) {
+      setPendingType(newType);
+    } else {
+      applyChange(newType);
+    }
+  };
+
+  const confirm = () => {
+    applyChange(pendingType);
+    setPendingType(null);
+  };
+
+  const cancel = () => setPendingType(null);
+
+  return { pendingType, request, confirm, cancel };
+}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -823,6 +823,7 @@
       "label": "Wert",
       "placeholder": "Wert eingeben…"
     },
+    "arrayItemType": "Elementtyp",
     "description": {
       "label": "Beschreibung",
       "placeholder": "Optionale Beschreibung…"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -824,6 +824,16 @@
       "placeholder": "Wert eingeben…"
     },
     "arrayItemType": "Elementtyp",
+    "typeChangeWarning": {
+      "message": "Ein Wechsel des Typs zu {{type}} löscht den aktuellen Wert.",
+      "confirm": "Trotzdem ändern",
+      "cancel": "Abbrechen"
+    },
+    "yaml": {
+      "invalid": "Ungültiges YAML: {{message}}",
+      "expectedObject": "Wert muss ein YAML-Objekt sein",
+      "expectedArray": "Wert muss eine YAML-Liste sein"
+    },
     "description": {
       "label": "Beschreibung",
       "placeholder": "Optionale Beschreibung…"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -823,6 +823,7 @@
       "label": "Value",
       "placeholder": "Enter value..."
     },
+    "arrayItemType": "Item type",
     "description": {
       "label": "Description",
       "placeholder": "Optional description..."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -824,6 +824,16 @@
       "placeholder": "Enter value..."
     },
     "arrayItemType": "Item type",
+    "typeChangeWarning": {
+      "message": "Changing the type to {{type}} will clear the current value.",
+      "confirm": "Change anyway",
+      "cancel": "Cancel"
+    },
+    "yaml": {
+      "invalid": "Invalid YAML: {{message}}",
+      "expectedObject": "Value must be a YAML object",
+      "expectedArray": "Value must be a YAML list"
+    },
     "description": {
       "label": "Description",
       "placeholder": "Optional description..."


### PR DESCRIPTION
Extends the `CustomPropertiesEditor` with richer value editing.

## What changed

**Typed array editing (`TypedArrayEditor`)**
- Select the element type (string / number / boolean / object) and edit arrays inline in the ArrayInput style.
- Number rows allow an empty field (no forced leading zero); empty entries are excluded from the stored array.
- Boolean rows have an "unset" state, so an untouched row isn't stored as `false`.
- Switching to an array (or adding the first element) auto-shows one editable row — but it stays out of the stored value until it has content.

**Object / array-of-objects as YAML (`ObjectYamlEditor`)**
- Object values, and arrays whose element type is `object`, are edited as free-form YAML in Monaco with syntax highlighting and validation.
- Uses a dedicated `object-yaml` language + unique model path, so the data-contract schema, ODCS completions, and monaco-yaml "Inline schema" / "No suggestions" popups don't apply here.

**Type-change safety**
- Destructive value/element type changes (that would clear the current value) now prompt an inline confirmation, via a shared `usePendingTypeChange` hook and `TypeChangeWarning` component.

**Other**
- The value-type selector is always a dropdown (removed the click-to-edit span).
- Value is displayed below the property field; description textarea starts at one row.
- Scoped the main `YamlEditor` ODCS schema to the contract model (`fileMatch: ['datacontract.yaml']`).

## Testing
Verified manually in the running app (form + YAML views): string/number/boolean/object arrays round-trip to correct YAML, destructive-change warnings fire and can be confirmed/cancelled, the object editor shows no schema suggestions, and the main contract editor still validates against the ODCS schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)