### PR TITLE
Customization: `yaml` field type (free-form YAML value)

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -179,8 +179,7 @@ Currently implemented in the property detail drawer (`schema.properties` level).
 | `select` | Single-select dropdown | `enum` (required) |
 | `multiselect` | Multi-select dropdown | `enum` (required) |
 | `array` | Array of strings | `placeholder`, `minItems`, `maxItems` |
-| `object` | Object edited as YAML | - |
-| `objectArray` | Array of objects edited as YAML | `minItems`, `maxItems` |
+| `yaml` | Any value (object, list, or scalar) edited as free-form YAML | - |
 | `boolean` | Toggle/checkbox | - |
 | `date` | Date picker | `minimum`, `maximum` |
 | `datetime` | Date and time picker | `minimum`, `maximum` |

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -179,6 +179,8 @@ Currently implemented in the property detail drawer (`schema.properties` level).
 | `select` | Single-select dropdown | `enum` (required) |
 | `multiselect` | Multi-select dropdown | `enum` (required) |
 | `array` | Array of strings | `placeholder`, `minItems`, `maxItems` |
+| `object` | Object edited as YAML | - |
+| `objectArray` | Array of objects edited as YAML | `minItems`, `maxItems` |
 | `boolean` | Toggle/checkbox | - |
 | `date` | Date picker | `minimum`, `maximum` |
 | `datetime` | Date and time picker | `minimum`, `maximum` |

--- a/embed-customizations.html
+++ b/embed-customizations.html
@@ -131,6 +131,19 @@
             type: 'textarea',
             description: 'Internal notes about this contract',
             rows: 4
+          },
+          {
+            property: 'retentionConfig',
+            title: 'Retention Config',
+            type: 'object',
+            description: 'A structured object value, edited as free-form YAML'
+          },
+          {
+            property: 'contacts',
+            title: 'Contacts',
+            type: 'objectArray',
+            description: 'A list of objects, edited as free-form YAML',
+            minItems: 1
           }
         ],
         customSections: [
@@ -143,6 +156,11 @@
             section: 'lifecycle',
             title: 'Lifecycle',
             customProperties: ['retentionDays', 'effectiveDate', 'isPublic']
+          },
+          {
+            section: 'configuration',
+            title: 'Configuration',
+            customProperties: ['retentionConfig', 'contacts']
           }
         ]
       },
@@ -481,6 +499,21 @@ customProperties:
     value: 365
   - property: isPublic
     value: false
+  - property: retentionConfig
+    value:
+      days: 365
+      enabled: true
+      tiers:
+        - hot
+        - cold
+  - property: contacts
+    value:
+      - name: Jane Doe
+        role: owner
+        email: jane.doe@company.com
+      - name: Bob Smith
+        role: steward
+        email: bob.smith@company.com
 schema:
   - name: transactions
     description: Financial transactions

--- a/embed-customizations.html
+++ b/embed-customizations.html
@@ -135,15 +135,14 @@
           {
             property: 'retentionConfig',
             title: 'Retention Config',
-            type: 'object',
+            type: 'yaml',
             description: 'A structured object value, edited as free-form YAML'
           },
           {
             property: 'contacts',
             title: 'Contacts',
-            type: 'objectArray',
-            description: 'A list of objects, edited as free-form YAML',
-            minItems: 1
+            type: 'yaml',
+            description: 'A list of objects, edited as free-form YAML'
           }
         ],
         customSections: [

--- a/src/components/ui/CustomPropertyField.jsx
+++ b/src/components/ui/CustomPropertyField.jsx
@@ -553,20 +553,14 @@ const ArrayField = ({ config, value, onChange, errors }) => {
 };
 
 /**
- * Object / array-of-objects field sub-component.
- * Edits the value as free-form YAML via ObjectYamlEditor; the stored value is a real
- * object (kind="object") or array (kind="array"). An empty value is stored as undefined
- * so `required` still applies and the property isn't persisted while empty.
+ * YAML field sub-component.
+ * Edits the value as free-form YAML via ObjectYamlEditor, accepting any valid YAML
+ * (object, list, or scalar) and surfacing a syntax error inline while invalid. The stored
+ * value is the parsed value; an empty editor stores undefined so `required` still applies.
  */
-const ObjectField = ({ config, value, onChange, errors, kind }) => {
+const YamlField = ({ config, value, onChange, errors }) => {
   const { t } = useTranslation();
   const { property, title, description, required } = config;
-
-  const isEmpty = (val) => {
-    if (val === null || val === undefined) return true;
-    if (kind === 'array') return Array.isArray(val) && val.length === 0;
-    return typeof val === 'object' && !Array.isArray(val) && Object.keys(val).length === 0;
-  };
 
   return (
     <div>
@@ -586,9 +580,9 @@ const ObjectField = ({ config, value, onChange, errors, kind }) => {
         )}
       </div>
       <ObjectYamlEditor
-        kind={kind}
+        kind="yaml"
         value={value}
-        onChange={(val) => onChange(isEmpty(val) ? undefined : val)}
+        onChange={(val) => onChange(val === null || val === undefined ? undefined : val)}
       />
       {errors?.map((err, i) => (
         <p key={i} className="mt-1 text-xs text-red-600">
@@ -705,25 +699,13 @@ const CustomPropertyField = ({
     case 'boolean':
       return <BooleanField config={config} value={value} onChange={onChange} />;
 
-    case 'object':
+    case 'yaml':
       return (
-        <ObjectField
+        <YamlField
           config={config}
           value={value}
           onChange={onChange}
           errors={validationErrors}
-          kind="object"
-        />
-      );
-
-    case 'objectArray':
-      return (
-        <ObjectField
-          config={config}
-          value={value}
-          onChange={onChange}
-          errors={validationErrors}
-          kind="array"
         />
       );
 

--- a/src/components/ui/CustomPropertyField.jsx
+++ b/src/components/ui/CustomPropertyField.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import ValidatedInput from './ValidatedInput';
 import { ValidatedCombobox } from './index';
 import TagsInput from './TagsInput.jsx';
+import ObjectYamlEditor from './ObjectYamlEditor.jsx';
 import Tooltip from './Tooltip';
 import QuestionMarkCircleIcon from './icons/QuestionMarkCircleIcon';
 import ChevronDownIcon from './icons/ChevronDownIcon';
@@ -552,6 +553,53 @@ const ArrayField = ({ config, value, onChange, errors }) => {
 };
 
 /**
+ * Object / array-of-objects field sub-component.
+ * Edits the value as free-form YAML via ObjectYamlEditor; the stored value is a real
+ * object (kind="object") or array (kind="array"). An empty value is stored as undefined
+ * so `required` still applies and the property isn't persisted while empty.
+ */
+const ObjectField = ({ config, value, onChange, errors, kind }) => {
+  const { t } = useTranslation();
+  const { property, title, description, required } = config;
+
+  const isEmpty = (val) => {
+    if (val === null || val === undefined) return true;
+    if (kind === 'array') return Array.isArray(val) && val.length === 0;
+    return typeof val === 'object' && !Array.isArray(val) && Object.keys(val).length === 0;
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-1 mb-1">
+        <label className="block text-xs font-medium leading-4 text-gray-900">
+          <FieldLabel title={title} property={property} />
+        </label>
+        {description && (
+          <Tooltip content={description}>
+            <QuestionMarkCircleIcon />
+          </Tooltip>
+        )}
+        {required && (
+          <span className="ml-auto text-xs leading-4 text-gray-500">
+            {t('customProperty.required')}
+          </span>
+        )}
+      </div>
+      <ObjectYamlEditor
+        kind={kind}
+        value={value}
+        onChange={(val) => onChange(isEmpty(val) ? undefined : val)}
+      />
+      {errors?.map((err, i) => (
+        <p key={i} className="mt-1 text-xs text-red-600">
+          {err}
+        </p>
+      ))}
+    </div>
+  );
+};
+
+/**
  * Main CustomPropertyField component
  * Renders a custom property field based on its type configuration
  *
@@ -656,6 +704,28 @@ const CustomPropertyField = ({
 
     case 'boolean':
       return <BooleanField config={config} value={value} onChange={onChange} />;
+
+    case 'object':
+      return (
+        <ObjectField
+          config={config}
+          value={value}
+          onChange={onChange}
+          errors={validationErrors}
+          kind="object"
+        />
+      );
+
+    case 'objectArray':
+      return (
+        <ObjectField
+          config={config}
+          value={value}
+          onChange={onChange}
+          errors={validationErrors}
+          kind="array"
+        />
+      );
 
     case 'date':
     case 'datetime':

--- a/src/components/ui/CustomSection.jsx
+++ b/src/components/ui/CustomSection.jsx
@@ -291,16 +291,18 @@ export const UngroupedCustomProperties = ({
 		);
 	}, [customProperties, groupedNames]);
 
-	if (ungroupedProps.length === 0) {
-		return null;
-	}
-
-	// Build context including current custom property values
+	// Build context including current custom property values. Kept before the
+	// early return so the hook order stays stable when ungroupedProps changes
+	// from empty to non-empty (e.g. customizations loaded asynchronously).
 	const extendedContext = useMemo(() => ({
 		...context,
 		...values,
 		customProperties: values,
 	}), [context, values]);
+
+	if (ungroupedProps.length === 0) {
+		return null;
+	}
 
 	return (
 		<div className="space-y-3">

--- a/src/components/ui/ObjectYamlEditor.jsx
+++ b/src/components/ui/ObjectYamlEditor.jsx
@@ -17,24 +17,29 @@ if (monaco?.languages && !monaco.languages.getLanguages().some((l) => l.id === O
 }
 
 /**
- * ObjectYamlEditor edits an object (or an array of objects) as free-form YAML using
- * Monaco, with syntax highlighting. It keeps local text so partially-typed / temporarily
- * invalid YAML is not clobbered, parses on every change, and only propagates a valid
- * value of the expected shape. Invalid input shows an inline error and leaves the last
- * valid value untouched.
+ * ObjectYamlEditor edits a value as free-form YAML using Monaco, with syntax highlighting.
+ * It keeps local text so partially-typed / temporarily invalid YAML is not clobbered,
+ * parses on every change, and propagates the parsed value once it is valid. Invalid input
+ * shows an inline error and leaves the last valid value untouched.
  *
- * @param {object|Array} value - The current object or array value
+ * The `kind` constrains the accepted shape:
+ * - `'object'`: must parse to a YAML mapping
+ * - `'array'`: must parse to a YAML sequence
+ * - `'yaml'`: any valid YAML (object, list, or scalar); only syntax is validated
+ *
+ * @param {*} value - The current value
  * @param {Function} onChange - Called with the parsed value when it is valid
- * @param {'object'|'array'} kind - Whether the value is a single object or an array
+ * @param {'object'|'array'|'yaml'} kind - Accepted YAML shape (see above)
  * @param {number} height - Editor height in pixels
  */
-const emptyFor = (kind) => (kind === 'array' ? [] : {});
+const emptyFor = (kind) => (kind === 'array' ? [] : kind === 'yaml' ? undefined : {});
 
 const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
 const toYaml = (value, kind) => {
   const v = value == null ? emptyFor(kind) : value;
   // Start empty for empty values so the editor is a clean slate to type into.
+  if (v === null || v === undefined) return '';
   if (kind === 'array' && Array.isArray(v) && v.length === 0) return '';
   if (kind === 'object' && isPlainObject(v) && Object.keys(v).length === 0) return '';
   try {
@@ -87,10 +92,13 @@ const ObjectYamlEditor = ({ value, onChange, kind = 'object', height = 180 }) =>
         setError(t('customProperty.yaml.expectedArray'));
         return;
       }
-    } else if (!isPlainObject(parsed)) {
-      setError(t('customProperty.yaml.expectedObject'));
-      return;
+    } else if (kind === 'object') {
+      if (!isPlainObject(parsed)) {
+        setError(t('customProperty.yaml.expectedObject'));
+        return;
+      }
     }
+    // kind === 'yaml': any valid YAML is accepted; only syntax is validated above.
 
     setError(null);
     onChange(parsed);


### PR DESCRIPTION
Adds a new custom-property **field type** for customization YAML: `yaml`, backed by the free-form Monaco YAML editor introduced in #54.

## What it does

- **`type: yaml`** — edits a value as free-form YAML in the Monaco editor (`ObjectYamlEditor`, `kind="yaml"`).
- Accepts **any valid YAML** — object, list, or scalar — and **validates its syntax**, showing an inline error while invalid.
- The stored value is the parsed value, so the details/preview reuses the existing `PropertyValueRenderer` object view unchanged — no preview code needed.

(An earlier iteration of this PR had separate `object` and `objectArray` types; they were merged into the single `yaml` type.)

### Bug fix
Fixes a latent Rules-of-Hooks violation in `UngroupedCustomProperties` (an early `return null` sat between `useMemo` calls). It was harmless with synchronous configs but crashed the form when custom-property configs load asynchronously (e.g. via `/config.json`). Moved the `extendedContext` `useMemo` above the early return.

### Docs / examples
- `CUSTOMIZATION.md` Property Types table gains a `yaml` row.
- `embed-customizations.html` gains a **Configuration** section demonstrating the `yaml` type with both an object-shaped and an array-shaped value, pre-filled in the sample YAML.

## Testing
Verified in the embed example (`embed-customizations.html`): a `type: yaml` field renders both an object value (`retentionConfig`) and an array value (`contacts`) as YAML editors, round-trips to correct YAML, renders in the preview via the existing object view, and shows a syntax error for invalid YAML (e.g. `foo: bar: baz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)