### PR TITLE
Lock the ID field when the contract is used by data products

### DIFF
--- a/src/embed.jsx
+++ b/src/embed.jsx
@@ -99,6 +99,10 @@ const DEFAULT_CONFIG = {
   managedTags: [], // [{tag: 'tag1', href: 'https://...'}, ...]
   allowUnmanagedTags: true,
 
+  // Data products referencing this contract via a port. When non-empty the ID (`id`) field is
+  // locked, since renaming would break those references. [{name, externalId}, ...]
+  dataProductsUsingContract: [],
+
   // Optional lists for dropdowns (if not provided, text fields are used)
   teams: null,         // Array of {id: string, name: string} or null
   domains: null,       // Array of {id: string, name: string} or null
@@ -386,6 +390,7 @@ function createConfiguredStore(config) {
 				semantics: config.semantics,
         managedTags: config.managedTags,
         allowUnmanagedTags: config.allowUnmanagedTags,
+				dataProductsUsingContract: config.dataProductsUsingContract,
 				teams: config.teams,
 				domains: config.domains,
 				tests: config.tests,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -30,7 +30,8 @@
     },
     "id": {
       "label": "ID",
-      "tooltip": "Eindeutige Kennung für diesen Data Contract"
+      "tooltip": "Eindeutige Kennung für diesen Data Contract",
+      "usedByDataProducts": "Diese ID kann nicht geändert werden, solange sie von Data Products verwendet wird: {{products}}."
     },
     "status": {
       "label": "Status",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -30,7 +30,8 @@
     },
     "id": {
       "label": "ID",
-      "tooltip": "Unique identifier for this data contract"
+      "tooltip": "Unique identifier for this data contract",
+      "usedByDataProducts": "This ID can't be changed while it's used by data products: {{products}}."
     },
     "status": {
       "label": "Status",

--- a/src/routes/Overview.jsx
+++ b/src/routes/Overview.jsx
@@ -40,6 +40,11 @@ const Overview = () => {
 
 	const editorConfig = useEditorStore((state) => state.editorConfig);
 
+	// Data products that reference this contract via a port lock the ID: renaming it would break the
+	// ODPS contractId references and external URLs pointing at this contract.
+	const dataProductsUsingContract = editorConfig.dataProductsUsingContract || [];
+	const isIdLocked = dataProductsUsingContract.length > 0;
+
 	// Get customization config for root level
 	const { customProperties: customPropertyConfigs, customSections } = useCustomization('root');
 
@@ -198,21 +203,32 @@ const Overview = () => {
 
 								{/* ID Field */}
 								{!isIdHidden && (
-									<ValidatedInput
-										name="id"
-										label={idOverride?.title || t("overview.id.label")}
-										value={id}
-										onChange={(e) => setId(e.target.value)}
-										required={idOverride?.required ?? true}
-										tooltip={idOverride?.description || t("overview.id.tooltip")}
-										placeholder={idOverride?.placeholder || "unique-identifier"}
-										pattern={idOverride?.pattern}
-										patternMessage={idOverride?.patternMessage}
-										minLength={idOverride?.minLength}
-										maxLength={idOverride?.maxLength}
-										validationKey="root.id"
-										validationSection="Overview"
-									/>
+									<div>
+										<ValidatedInput
+											name="id"
+											label={idOverride?.title || t("overview.id.label")}
+											value={id}
+											onChange={(e) => setId(e.target.value)}
+											required={idOverride?.required ?? true}
+											tooltip={idOverride?.description || t("overview.id.tooltip")}
+											placeholder={idOverride?.placeholder || "unique-identifier"}
+											pattern={idOverride?.pattern}
+											patternMessage={idOverride?.patternMessage}
+											minLength={idOverride?.minLength}
+											maxLength={idOverride?.maxLength}
+											validationKey="root.id"
+											validationSection="Overview"
+											disabled={isIdLocked}
+											skipInternalValidation={isIdLocked}
+										/>
+										{isIdLocked && (
+											<p className="mt-1 text-xs text-gray-500">
+												{t("overview.id.usedByDataProducts", {
+													products: dataProductsUsingContract.map((d) => d.name).join(", "),
+												})}
+											</p>
+										)}
+									</div>
 								)}
 
 								{/* Status Field */}


### PR DESCRIPTION
## What

Adds a host-driven lock on the Overview **ID** field. When the embedding app passes a non-empty `dataProductsUsingContract` config, the ID input is disabled and an inline note lists the data products that reference the contract.

Renaming a contract's `id` would silently break the ODPS `contractId` references on data product ports and every external URL pointing at the contract, so the host locks the field while the contract is in use. The backend rejects such a rename regardless; this is the matching UX.

## Changes

- **`embed.jsx`** — new `dataProductsUsingContract` config (default `[]`), surfaced on `editorConfig`.
- **`routes/Overview.jsx`** — when `editorConfig.dataProductsUsingContract` is non-empty, pass `disabled` + `skipInternalValidation` to the id `ValidatedInput` and render a note listing the products.
- **i18n** — new `overview.id.usedByDataProducts` key (en + de).

## Notes

- No behavior change when the host passes nothing (default `[]` → field editable as before).
- The embedding host (entropy-data) computes the list and passes it through `init({ dataProductsUsingContract })`.