### PR TITLE
Declare least-privilege GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/azure-static-web-apps-orange-desert-03e149203.yml
+++ b/.github/workflows/azure-static-web-apps-orange-desert-03e149203.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.event.action != 'closed'
@@ -27,6 +30,9 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     name: Build and Deploy Job
+    permissions:
+      contents: read
+      pull-requests: write # Azure/static-web-apps-deploy posts preview URLs as PR comments
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,6 +61,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job
+    permissions: {} # Uses only the Azure deployment token, no GITHUB_TOKEN access needed
     steps:
       - name: Close Pull Request
         id: closepullrequest

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -2,6 +2,9 @@ name: license.yml
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Both workflows relied on the repository default token scope. Add an explicit top-level `contents: read`, grant `pull-requests: write` to the deploy job so the Azure SWA action can keep posting preview URLs, and drop all token access from the close-PR job, which authenticates only with the Azure deployment token.

Closes the four actions/missing-workflow-permissions code scanning alerts.