### PR TITLE
Serve static files from a startup index instead of a resolved path

### DIFF
--- a/bin/datacontract-editor.js
+++ b/bin/datacontract-editor.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { createServer } from 'http';
-import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { join, extname, resolve, basename, sep } from 'path';
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { join, extname, resolve, basename } from 'path';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 
@@ -127,22 +127,38 @@ function sendJson(res, statusCode, data) {
   res.end(JSON.stringify(data));
 }
 
-// Resolve a request path against dist/ and return it only if it stays inside.
-// Returns null for traversal attempts and malformed percent-encoding.
-function resolveWithinDist(url) {
-  let decoded;
-  try {
-    decoded = decodeURIComponent(url);
-  } catch {
-    return null; // malformed percent-encoding
+// Index every file under dist/ once at startup, keyed by the URL path it is
+// served at. Requests then only ever look up a key in this map: the paths handed
+// to the filesystem come from readdirSync, never from the request, so a request
+// path cannot address a file outside dist/ no matter how it is encoded.
+function indexDistFiles(dir, urlPrefix = '') {
+  const files = new Map();
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const urlPath = `${urlPrefix}/${entry.name}`;
+    if (entry.isDirectory()) {
+      for (const [key, value] of indexDistFiles(join(dir, entry.name), urlPath)) {
+        files.set(key, value);
+      }
+    } else if (entry.isFile()) {
+      files.set(urlPath, join(dir, entry.name));
+    }
   }
 
-  if (decoded.includes('\0')) return null;
+  return files;
+}
 
-  const candidate = resolve(distDir, '.' + (decoded.startsWith('/') ? decoded : '/' + decoded));
-  if (candidate !== distDir && !candidate.startsWith(distDir + sep)) return null;
+// dist/ is a build artifact and does not change while the server runs.
+const distFiles = indexDistFiles(distDir);
 
-  return candidate;
+// Turn a request path into a lookup key. Returns null when the percent-encoding
+// is malformed, which simply means no file will match.
+function toLookupKey(url) {
+  try {
+    return decodeURIComponent(url);
+  } catch {
+    return null;
+  }
 }
 
 // The server is only ever meant to be reached by a browser on this machine.
@@ -329,27 +345,11 @@ const server = createServer(async (req, res) => {
     url = '/index.html';
   }
 
-  // Resolve the request path inside dist/ and refuse anything that escapes it.
-  // req.url is attacker-controlled and is not normalized by Node, so a client
-  // that does not collapse '..' itself (curl --path-as-is) could otherwise read
-  // any file on the machine.
-  const safePath = resolveWithinDist(url);
-  if (!safePath) {
-    res.writeHead(403);
-    res.end('Forbidden');
-    return;
-  }
+  // Serve a known file from dist/, or fall back to index.html for SPA routes
+  const lookupKey = toLookupKey(url);
+  const filePath = lookupKey === null ? undefined : distFiles.get(lookupKey);
 
-  let filePath = safePath;
-  const ext = extname(filePath).toLowerCase();
-
-  // If no extension, serve index.html (SPA routing)
-  if (!ext && !existsSync(filePath)) {
-    filePath = indexPath;
-  }
-
-  // Try to serve the file
-  if (existsSync(filePath)) {
+  if (filePath) {
     try {
       const content = readFileSync(filePath);
       const contentType = mimeTypes[extname(filePath).toLowerCase()] || 'application/octet-stream';


### PR DESCRIPTION
Follow-up to #68. Code scanning alerts #5, #6 and #7 (`js/path-injection`) are still open after the rescan of `main` at `9a85824`, now reported at lines 347, 352 and 354.

The containment check from #68 is sound: the request path was resolved against `dist/` and refused if it escaped, and the traversal is genuinely blocked (verified with `curl --path-as-is`). CodeQL just does not treat a `startsWith` check on a computed prefix, returned across a function boundary, as a barrier, so it keeps tracing `req.url` into `existsSync` and `readFileSync`.

Rather than reshaping the check until the query is satisfied, this removes the dataflow.

`dist/` is a build artifact that does not change while the server runs, so it is indexed once at startup into a map keyed by the URL path each file is served at. A request path is now only ever a **lookup key**; the paths passed to the filesystem come from `readdirSync`. Nothing derived from the request reaches `fs`, so there is no flow left to flag and no containment check to get subtly wrong.

Unknown paths fall back to `index.html` exactly as before, so traversal attempts now receive the SPA shell rather than a 403. That is the same response any unknown route gets.

## Verification

Against a running server:

| Request | Result |
| --- | --- |
| `--path-as-is /../package.json` | 200, body is `<!doctype html>`, not the file |
| `--path-as-is /../../../../../etc/passwd` | 200, SPA shell |
| `/%2e%2e/package.json` | 200, SPA shell |
| `/..%2f..%2fetc/passwd` | 200, SPA shell |
| `Host: evil.example` | 403 |

All 9 files in `dist/` are indexed and still serve: `/`, `/index.html`, `/datacontract-editor.es.js`, `/monaco-4.7.0.js`, `/assets/yaml.worker-4.7.0.js` all return 200, as does `/api/health`.

Checked in headless Chromium against the built output: Form, YAML and Diagram views render, Monaco loads with YAML highlighting, React Flow renders, and a same-origin `PUT` through the app's own save path returns 200 with the file on disk updated. No failed requests, no console errors.

One behavioural note: because the index is built at startup, rebuilding `dist/` while the server is running will not be picked up until restart. The CLI serves a prebuilt `dist/` and `npm start` builds before serving, so this does not affect normal use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)