### PR TITLE
Fix AI assistant button not showing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -60,21 +60,25 @@
     </noscript>
     <div id="root"></div>
     <script type="module">
-      import { init, loadCustomizationYaml } from './datacontract-editor.es.js';
+      import { init, loadRuntimeConfig, buildEditorConfig } from './datacontract-editor.es.js';
 
-      // Optional customization.yaml served next to the app, see CUSTOMIZATION.md
-      const customizations = await loadCustomizationYaml();
+      // Runtime config: /config.json (generated from env vars by the Docker image, see
+      // CONFIGURATION.md) plus an optional customization.yaml served next to the app.
+      // This is a library build, so src/main.jsx never ships and this file is the only
+      // place the standalone/Docker bootstrap can pick the AI and tests config up.
+      const editorConfig = buildEditorConfig(await loadRuntimeConfig());
 
       init({
         container: '#root',
         mode: 'SERVER',
         persistence: 'localStorage',
         initialView: 'form',
+        ...editorConfig,
         tests: {
           enabled: true,
-          dataContractCliApiServerUrl: 'https://api.datacontract.com'
+          dataContractCliApiServerUrl: 'https://api.datacontract.com',
+          ...editorConfig.tests,
         },
-        customizations,
       });
     </script>
   </body>

--- a/src/config/runtimeConfig.js
+++ b/src/config/runtimeConfig.js
@@ -91,12 +91,16 @@ export function buildEditorConfig(runtimeConfig) {
   if (runtimeConfig.ai !== undefined) {
     if (runtimeConfig.ai.enabled === false) {
       config.ai = { enabled: false };
-    } else if (runtimeConfig.ai.endpoint && runtimeConfig.ai.apiKey) {
+    } else if (runtimeConfig.ai.enabled === true && runtimeConfig.ai.endpoint) {
+      // The API key is optional: an auth-less proxy / LiteLLM gateway (see AI_PROXY.md)
+      // keeps the real provider key server-side, so AI_API_KEY is empty. The provider
+      // adapters gate on `if (config.apiKey)` and just omit the auth header when it is
+      // blank, matching the `|| ''` idiom in config/defaults.js.
       config.ai = {
         enabled: true,
         provider: runtimeConfig.ai.provider || 'openai',
         endpoint: runtimeConfig.ai.endpoint,
-        apiKey: runtimeConfig.ai.apiKey,
+        apiKey: runtimeConfig.ai.apiKey || '',
         model: runtimeConfig.ai.model,
         authHeader: runtimeConfig.ai.authHeader || 'bearer',
         headers: runtimeConfig.ai.headers || {},

--- a/src/embed.jsx
+++ b/src/embed.jsx
@@ -428,6 +428,27 @@ function createConfiguredStore(config) {
         name: 'editor-store',
         storage: storageConfig,
         partialize: ({ authoritativeDefinitions, ...rest }) => rest, // eslint-disable-line no-unused-vars
+        // Deep-merge editorConfig on rehydrate (mirrors src/store.js). The default
+        // shallow merge lets a stale persisted editorConfig replace the one just
+        // built from init() config — which hides the AI assistant when it was
+        // enabled after the store was first persisted. init() config wins for `ai`
+        // (there is no in-app AI settings UI); user-editable `tests` values persist.
+        merge: (persistedState, currentState) => ({
+          ...currentState,
+          ...persistedState,
+          editorConfig: {
+            ...currentState.editorConfig,
+            ...persistedState?.editorConfig,
+            ai: {
+              ...persistedState?.editorConfig?.ai,
+              ...currentState.editorConfig?.ai,
+            },
+            tests: {
+              ...currentState.editorConfig?.tests,
+              ...persistedState?.editorConfig?.tests,
+            },
+          },
+        }),
       })
     );
   } else {
@@ -677,7 +698,10 @@ export function getFileStorageBackend() {
 export { parseYaml };
 
 /**
- * Fetch and parse a customization.yaml served next to the app (see CUSTOMIZATION.md).
- * Resolves to null when there is none. Used by the standalone index.html bootstrap.
+ * Runtime config helpers used by the standalone index.html bootstrap:
+ * - loadCustomizationYaml: fetch/parse a customization.yaml served next to the app.
+ * - loadRuntimeConfig: fetch /config.json (Docker deployments) and fold in customization.yaml.
+ * - buildEditorConfig: turn that runtime config into an init() config fragment.
+ * See CUSTOMIZATION.md and CONFIGURATION.md.
  */
-export { loadCustomizationYaml } from './config/runtimeConfig.js';
+export { loadCustomizationYaml, loadRuntimeConfig, buildEditorConfig } from './config/runtimeConfig.js';


### PR DESCRIPTION
The AI assistant button never appeared when the editor is configured at runtime
through `/config.json` (`ai.enabled: true` + endpoint + key) instead of build-time
`VITE_AI_*` env vars (#30).

The production build is a Vite library build (`build.lib.entry = src/embed.jsx`), so
`src/main.jsx` and the root `index.html` never ship — only the dev server uses them.
The page that is actually served is `public/index.html`, copied into `dist/` verbatim.
That bootstrap calls `init()` without ever fetching `/config.json`, so a runtime
config served next to the app is read by nobody: `loadRuntimeConfig()` /
`buildEditorConfig()` were only wired into the dead `src/main.jsx`. The store falls
back to `DEFAULT_AI_CONFIG`, whose `enabled` is derived from the build-time
`VITE_AI_API_KEY` — which a runtime-configured deploy does not set — so
`AiFloatingActionButton` and `AiSidebar` stay hidden. This is the same gap #70 left
when it wired `/customization.yaml` into the shipped `index.html` and not
`/config.json`.

## What changed

- **`public/index.html`** — fetch `/config.json` via `loadRuntimeConfig()` /
  `buildEditorConfig()` (both now re-exported from `embed.jsx`) and spread the result
  into `init()`, keeping the hard-coded `tests` default unless `config.json` overrides it.
- **`src/embed.jsx`** — give the persisted store a custom `merge` (mirrors `src/store.js`).
  The default shallow merge let a stale persisted `editorConfig` replace the one just
  built from `init()` config and re-hide the assistant on reload; `init()` config now
  wins for `ai` (there is no in-app AI settings UI), while user-editable `tests` values
  keep their persisted state.
- **`buildEditorConfig`** — accept an explicitly enabled AI config without an API key.
  An auth-less proxy / LiteLLM gateway (`AI_PROXY.md`) keeps the real key server-side, so
  the key is empty; the provider adapters already omit the auth header when the key is
  blank.

## Verification

`npm run build` + `npm run preview` against a hand-written `dist/config.json`:

| Scenario | Result |
| --- | --- |
| `config.json` with OpenAI config (with key) | button appears, assistant panel opens |
| `config.json` with Anthropic-proxy config (no key, no `model`) | button appears, panel opens |
| no `config.json` | button stays hidden — no regression |
| `config.json` present + a stale persisted `editor-store` (`ai.enabled: false`) | button stays (without the `merge`: hidden) |
| user-edited `tests` URL/key + reload | persisted value kept |

Closes #30
